### PR TITLE
fix command in readme to generate protocol buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cd voxelize
 yarn
 
 # generate protocol buffers
-yarn run proto
+yarn --cwd transport run proto
 
 # start development
 yarn run dev


### PR DESCRIPTION
I found a little mistake in README while my setting up. 
`yarn run proto` command seems to be moved to `transport` dir since c394eb77
