### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 ]
 license = "MIT"
 name = "voxelize"
+repository = "https://github.com/voxelize/voxelize"
 version = "0.8.75"
 
 [lib]


### PR DESCRIPTION
While scraping crates.io I've found this crate to be missing the `repository` attribute, making it harder for crates.io users or automation to find the link to the repository. This PR fixes it.