### PR TITLE
Don't send LOAD messages if no chunks to load

### DIFF
--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -2610,19 +2610,23 @@ export class World<T = any> extends Scene implements NetIntercept {
 
     const toRequest = toRequestArray.slice(0, maxChunkRequestsPerUpdate);
 
-    this.packets.push({
-      type: "LOAD",
-      json: {
-        center,
-        direction: new Vector2(direction.x, direction.z).normalize().toArray(),
-        chunks: toRequest,
-      },
-    });
+    if (toRequest.length) {
+      this.packets.push({
+        type: "LOAD",
+        json: {
+          center,
+          direction: new Vector2(direction.x, direction.z)
+            .normalize()
+            .toArray(),
+          chunks: toRequest,
+        },
+      });
 
-    toRequest.forEach((coords) => {
-      const name = ChunkUtils.getChunkName(coords as Coords2);
-      this.chunks.requested.set(name, 0);
-    });
+      toRequest.forEach((coords) => {
+        const name = ChunkUtils.getChunkName(coords as Coords2);
+        this.chunks.requested.set(name, 0);
+      });
+    }
   }
 
   private processChunks(center: Coords2) {


### PR DESCRIPTION
This mostly fixes #31, there are still messages sent every second because of `vox-builtin:get-stats`