### PR TITLE
fix(server): prevent panic during client disconnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
     "vite-plugin-glsl": "^1.3.3",
     "vitest": "^1.6.1"
   },
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+  "packageManager": "pnpm@10.8.0"
 }


### PR DESCRIPTION
- Add error handling for entity deletion in remove_client
- Safely handle case when interactor component can't be found
- Use control flag to skip entity deletion when components are missing
- Add descriptive error logging for debugging disconnection issues
- Prevent crash during rapid client reconnection attempts