### PR TITLE
fix(physics): prevent large initial physics dt\n\nReset Stats timer d…

### DIFF
--- a/server/world/mod.rs
+++ b/server/world/mod.rs
@@ -1201,6 +1201,17 @@ impl World {
             body.0
                 .set_position(position.0 .0, position.0 .1, position.0 .2);
         }
+
+        // Reset the stats timing to avoid an unusually large delta on the very first tick caused
+        // by world setup and preloading delays. This ensures physics (e.g., rapier) receives a
+        // sensible time step and prevents entities such as boids from being launched away at
+        // server startup.
+        {
+            use std::time::SystemTime;
+            let mut stats = self.stats_mut();
+            stats.prev_time = SystemTime::now();
+            stats.delta = 0.0;
+        }
     }
 
     /// Preload the chunks in the world.

--- a/server/world/systems/stats/update.rs
+++ b/server/world/systems/stats/update.rs
@@ -20,6 +20,11 @@ impl<'a> System<'a> for UpdateStatsSystem {
             .as_nanos() as f32
             / 1000000000.0;
 
+        // Clamp delta to a reasonable range to prevent extremely large physics steps.
+        if stats.delta > 0.05 {
+            stats.delta = 0.05; // corresponds to a minimum of ~20 FPS
+        }
+
         if config.does_tick_time {
             stats.prev_time = now;
 


### PR DESCRIPTION
…uring world preparation and clamp delta within UpdateStatsSystem to 0.05s maximum. This avoids the extremely large first physics step that launched boids into unloaded chunks at server startup.