### PR TITLE
fix: use div wrapper for reliable README centering on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,22 @@
+<div align="center">
+
 <a href="https://shaoruu.io">
-  <p align="center">
-    <img src="examples/client/src/assets/logo-circle.png" width="100px" height="100px" />
-  </p>
-  <h1 align="center">Voxelize</h1>
+  <img src="examples/client/src/assets/logo-circle.png" width="100px" height="100px" />
 </a>
 
-<p align="center">A multiplayer, <i>super fast</i>, voxel engine in your browser!</p>
+<h1><a href="https://shaoruu.io">Voxelize</a></h1>
 
-<p align="center">
-  <a href="https://discord.gg/9483RZtWVU">
+<p>A multiplayer, <i>super fast</i>, voxel engine in your browser!</p>
+
+<a href="https://discord.gg/9483RZtWVU">
   <img alt="Discord Server" src="https://img.shields.io/discord/1229328337713762355?label=Discord&logo=Discord&style=for-the-badge">
-  </a>
-  <img src="https://img.shields.io/npm/v/@voxelize/core?logo=npm&style=for-the-badge">
-  <img src="https://img.shields.io/crates/v/voxelize?style=for-the-badge"/>
-</p>
-
-<a href="https://shaoruu.io">
-  <p align="center">
-  LIVE DEMO
-  </p>
 </a>
+<img src="https://img.shields.io/npm/v/@voxelize/core?logo=npm&style=for-the-badge">
+<img src="https://img.shields.io/crates/v/voxelize?style=for-the-badge"/>
+
+<a href="https://shaoruu.io">LIVE DEMO</a>
+
+</div>
 
 ![](/assets/Screenshot%202024-02-19%20at%201.37.53 AM.png)
 ![](/assets/Screen%20Shot%202022-07-13%20at%201.01.08%20AM.png)


### PR DESCRIPTION
Replace multiple <p align="center"> tags with a single <div align="center"> wrapper. GitHub's markdown renderer handles this more reliably and avoids issues with nested <p> inside <a> tags.