### PR TITLE
Cubic chunks world config

### DIFF
--- a/docs/docs/api/client/modules.md
+++ b/docs/docs/api/client/modules.md
@@ -1374,6 +1374,7 @@ The options defined on the server-side, passed to the client on network joining.
 | `fluidDensity` | `number` | The density of the fluid in this world. |
 | `fluidDrag` | `number` | The fluid drag of everything physical. |
 | `gravity` | `number`[] | The gravity of everything physical in this world. |
+| `cubicChunks` | `boolean` | Whether this world uses cubic chunks (infinite Y). When enabled, sunlight propagation is disabled. |
 | `maxChunk` | [`number`, `number`] | The maximum chunk coordinate of this world, inclusive. |
 | `maxHeight` | `number` | The height of a chunk, in blocks. |
 | `maxLightLevel` | `number` | The maximum light level that propagates in this world, including sunlight and torch light. |

--- a/docs/docs/tutorials/basics/4-world-configuration.md
+++ b/docs/docs/tutorials/basics/4-world-configuration.md
@@ -25,6 +25,18 @@ For infinite worlds, skip the boundaries:
 let config = WorldConfig::new().build();
 ```
 
+## Cubic Chunks
+
+Enable cubic chunks to remove the fixed world height and disable sunlight propagation:
+
+```rust title="Cubic Chunks"
+let config = WorldConfig::new()
+    .cubic_chunks(true)
+    .build();
+```
+
+When `cubic_chunks` is enabled, sunlight is treated as zero and only torch lights propagate.
+
 ## Time and Day Cycle
 
 ```rust title="Time Settings"

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -412,7 +412,7 @@ export type WorldClientOptions = {
   /**
    * Whether shader-based lighting is enabled for this world.
    * When enabled, lighting uses GPU shaders with cascaded shadow maps.
-   * CPU light propagation still runs to provide sunlight exposure data.
+   * CPU light propagation still runs to provide sunlight exposure data unless cubic chunks are enabled.
    * Defaults to `false`.
    */
   shaderBasedLighting: boolean;
@@ -577,7 +577,7 @@ export class World<T = any> extends Scene implements NetIntercept {
   /**
    * Whether shader-based lighting is enabled for this world.
    * When true, lighting uses GPU shaders with cascaded shadow maps.
-   * CPU light propagation still runs to provide sunlight exposure data.
+   * CPU light propagation still runs to provide sunlight exposure data unless cubic chunks are enabled.
    */
   public get usesShaderLighting(): boolean {
     return this.options.shaderBasedLighting === true;

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -3608,6 +3608,7 @@ export class World<T = any> extends Scene implements NetIntercept {
       maxHeight,
       subChunks,
       maxLightLevel,
+      cubicChunks,
       clientOnlyMeshing,
     } = this.options;
 
@@ -3633,6 +3634,7 @@ export class World<T = any> extends Scene implements NetIntercept {
           subChunks,
           size: chunkSize,
           maxLightLevel,
+          cubicChunks,
         });
       }
 

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -2542,13 +2542,17 @@ export class World<T = any> extends Scene implements NetIntercept {
       return;
     }
 
+    const isSunlight = color === "SUNLIGHT";
+
+    if (isSunlight && this.options.cubicChunks) {
+      return;
+    }
+
     const { maxHeight, minChunk, maxChunk, maxLightLevel, chunkSize } =
       this.options;
 
     const [startCX, startCZ] = minChunk;
     const [endCX, endCZ] = maxChunk;
-
-    const isSunlight = color === "SUNLIGHT";
 
     const blockCache = new Map<string, Block>();
     const rotationCache = new Map<string, BlockRotation>();
@@ -2662,13 +2666,17 @@ export class World<T = any> extends Scene implements NetIntercept {
     }
   }
   public removeLight(voxel: Coords3, color: LightColor) {
-    const { maxHeight, maxLightLevel, chunkSize, minChunk, maxChunk } =
-      this.options;
-
     const fill: LightNode[] = [];
     const queue: LightNode[] = [];
 
     const isSunlight = color === "SUNLIGHT";
+
+    if (isSunlight && this.options.cubicChunks) {
+      return;
+    }
+
+    const { maxHeight, maxLightLevel, chunkSize, minChunk, maxChunk } =
+      this.options;
     const [vx, vy, vz] = voxel;
 
     queue.push({
@@ -2778,10 +2786,16 @@ export class World<T = any> extends Scene implements NetIntercept {
    * This drastically improves performance when many contiguous light sources are removed at once.
    */
   public removeLightsBatch(voxels: Coords3[], color: LightColor) {
+    const isSunlight = color === "SUNLIGHT";
+
+    if (isSunlight && this.options.cubicChunks) {
+      return;
+    }
+
     if (!voxels.length) return;
 
     const { maxHeight, maxLightLevel } = this.options;
-    const isSunlight = color === "SUNLIGHT";
+
 
     const queue: LightNode[] = [];
     const fill: LightNode[] = [];

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -3156,6 +3156,10 @@ export class World<T = any> extends Scene implements NetIntercept {
       shaderBasedLighting: clientShaderBasedLighting,
     };
 
+    if (this.options.cubicChunks) {
+      this.chunkRenderer.uniforms.sunlightIntensity.value = 0;
+    }
+
     this.physics.options = this.options;
 
     // Initialize shader-based lighting components after server options are known

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -516,6 +516,11 @@ export type WorldServerOptions = {
    * Whether greedy meshing is enabled for this world.
    */
   greedyMeshing: boolean;
+
+  /**
+   * Whether this world uses cubic chunks (infinite Y). When enabled, sunlight propagation is disabled.
+   */
+  cubicChunks: boolean;
 };
 
 /**
@@ -4366,7 +4371,7 @@ export class World<T = any> extends Scene implements NetIntercept {
   private analyzeLightOperations(
     processedUpdates: ProcessedUpdate[]
   ): LightOperations {
-    const { maxHeight, maxLightLevel } = this.options;
+    const { maxHeight, maxLightLevel, cubicChunks } = this.options;
 
     interface RemovedLightSource {
       voxel: Coords3;
@@ -4776,25 +4781,28 @@ export class World<T = any> extends Scene implements NetIntercept {
       }
     }
 
+    const finalSunlightRemoval = cubicChunks ? [] : sunlightRemoval;
+    const finalSunFlood = cubicChunks ? [] : sunFlood;
+
     const hasOperations =
       redRemoval.length > 0 ||
       greenRemoval.length > 0 ||
       blueRemoval.length > 0 ||
-      sunlightRemoval.length > 0 ||
+      finalSunlightRemoval.length > 0 ||
       redFlood.length > 0 ||
       greenFlood.length > 0 ||
       blueFlood.length > 0 ||
-      sunFlood.length > 0;
+      finalSunFlood.length > 0;
 
     return {
       removals: {
-        sunlight: sunlightRemoval,
+        sunlight: finalSunlightRemoval,
         red: redRemoval,
         green: greenRemoval,
         blue: blueRemoval,
       },
       floods: {
-        sunlight: sunFlood,
+        sunlight: finalSunFlood,
         red: redFlood,
         green: greenFlood,
         blue: blueFlood,

--- a/packages/core/src/core/world/raw-chunk.ts
+++ b/packages/core/src/core/world/raw-chunk.ts
@@ -13,6 +13,7 @@ export type RawChunkOptions = {
   maxHeight: number;
   maxLightLevel: number;
   subChunks: number;
+  cubicChunks: boolean;
 };
 
 export class RawChunk {
@@ -433,6 +434,9 @@ export class RawChunk {
    */
   getSunlight(vx: number, vy: number, vz: number) {
     if (!this.contains(vx, vy, vz)) {
+      if (this.options.cubicChunks) {
+        return 0;
+      }
       if (vy < 0) {
         return 0;
       }

--- a/packages/core/src/core/world/raw-chunk.ts
+++ b/packages/core/src/core/world/raw-chunk.ts
@@ -433,10 +433,11 @@ export class RawChunk {
    * @returns The sunlight level at the given voxel coordinate. If the voxel coordinate is out of bounds, returns 0.
    */
   getSunlight(vx: number, vy: number, vz: number) {
+    if (this.options.cubicChunks) {
+      return 0;
+    }
+
     if (!this.contains(vx, vy, vz)) {
-      if (this.options.cubicChunks) {
-        return 0;
-      }
       if (vy < 0) {
         return 0;
       }

--- a/packages/core/src/core/world/workers/light-worker.ts
+++ b/packages/core/src/core/world/workers/light-worker.ts
@@ -164,12 +164,16 @@ function floodLight(
   max: Coords3 | undefined,
   options: WorldOptions
 ) {
+  const isSunlight = color === "SUNLIGHT";
+
+  if (isSunlight && options.cubicChunks) {
+    return;
+  }
+
   const { maxHeight, minChunk, maxChunk, maxLightLevel, chunkSize } = options;
 
   const [startCX, startCZ] = minChunk;
   const [endCX, endCZ] = maxChunk;
-
-  const isSunlight = color === "SUNLIGHT";
 
   const blockCache = new Map<number, Block>();
   const rotationCache = new Map<number, BlockRotation>();
@@ -288,12 +292,16 @@ function removeLight(
   color: LightColor,
   options: WorldOptions
 ): LightNode[] {
+  const isSunlight = color === "SUNLIGHT";
+
+  if (isSunlight && options.cubicChunks) {
+    return [];
+  }
+
   const { maxHeight, maxLightLevel } = options;
 
   const fill: LightNode[] = [];
   const queue: LightNode[] = [];
-
-  const isSunlight = color === "SUNLIGHT";
   const [vx, vy, vz] = voxel;
 
   queue.push({
@@ -378,14 +386,18 @@ function removeLightsBatch(
   color: LightColor,
   options: WorldOptions
 ): LightNode[] {
+  const isSunlight = color === "SUNLIGHT";
+
+  if (isSunlight && options.cubicChunks) {
+    return [];
+  }
+
   if (!voxels.length) return [];
 
   const { maxHeight, maxLightLevel } = options;
 
   const fill: LightNode[] = [];
   const queue: LightNode[] = [];
-
-  const isSunlight = color === "SUNLIGHT";
 
   voxels.forEach(([vx, vy, vz]) => {
     const level = isSunlight

--- a/packages/core/src/core/world/workers/mesh-worker.ts
+++ b/packages/core/src/core/world/workers/mesh-worker.ts
@@ -115,7 +115,8 @@ onmessage = async function (e) {
   }
 
   const { chunksData, min, max } = e.data;
-  const { chunkSize, greedyMeshing = true } = e.data.options as WorldOptions;
+  const { chunkSize, greedyMeshing = true, cubicChunks } = e.data
+    .options as WorldOptions;
 
   const chunks = chunksData.map(
     (
@@ -133,15 +134,24 @@ onmessage = async function (e) {
       const { x, z, voxels, lights, options } = chunkData;
       const { size, maxHeight } = options;
 
+      const voxelsArray =
+        voxels && voxels.byteLength
+          ? new Uint32Array(voxels)
+          : emptyUint32Array;
+      const lightsArray =
+        lights && lights.byteLength
+          ? new Uint32Array(lights)
+          : emptyUint32Array;
+
+      if (cubicChunks && lightsArray.length) {
+        for (let i = 0; i < lightsArray.length; i++) {
+          lightsArray[i] &= 0x0fff;
+        }
+      }
+
       return {
-        voxels:
-          voxels && voxels.byteLength
-            ? new Uint32Array(voxels)
-            : emptyUint32Array,
-        lights:
-          lights && lights.byteLength
-            ? new Uint32Array(lights)
-            : emptyUint32Array,
+        voxels: voxelsArray,
+        lights: lightsArray,
         shape: [size, maxHeight, size] as [number, number, number],
         min: [x * size, 0, z * size] as [number, number, number],
       };

--- a/server/world/config.rs
+++ b/server/world/config.rs
@@ -103,6 +103,9 @@ pub struct WorldConfig {
 
     /// Whether to use shader-based lighting instead of CPU light propagation. Default is false.
     pub shader_based_lighting: bool,
+
+    /// Whether this world uses cubic chunks (infinite Y). When enabled, sunlight propagation is disabled.
+    pub cubic_chunks: bool,
 }
 
 impl Default for WorldConfig {
@@ -153,6 +156,7 @@ const DEFAULT_SAVE_INTERVAL: usize = 300;
 const DEFAULT_COMMAND_SYMBOL: &str = "/";
 const DEFAULT_GREEDY_MESHING: bool = true;
 const DEFAULT_SHADER_BASED_LIGHTING: bool = false;
+const DEFAULT_CUBIC_CHUNKS: bool = false;
 
 /// Builder for a world configuration.
 pub struct WorldConfigBuilder {
@@ -189,6 +193,7 @@ pub struct WorldConfigBuilder {
     save_entities: bool,
     greedy_meshing: bool,
     shader_based_lighting: bool,
+    cubic_chunks: bool,
 }
 
 impl WorldConfigBuilder {
@@ -228,6 +233,7 @@ impl WorldConfigBuilder {
             save_entities: true,
             greedy_meshing: DEFAULT_GREEDY_MESHING,
             shader_based_lighting: DEFAULT_SHADER_BASED_LIGHTING,
+            cubic_chunks: DEFAULT_CUBIC_CHUNKS,
         }
     }
 
@@ -406,6 +412,12 @@ impl WorldConfigBuilder {
         self
     }
 
+    /// Configure whether this world uses cubic chunks. When enabled, sunlight propagation is disabled. Default is false.
+    pub fn cubic_chunks(mut self, cubic_chunks: bool) -> Self {
+        self.cubic_chunks = cubic_chunks;
+        self
+    }
+
     /// Create a world configuration.
     pub fn build(self) -> WorldConfig {
         // Make sure there are still chunks in the world.
@@ -455,6 +467,7 @@ impl WorldConfigBuilder {
             save_entities: self.save_entities,
             greedy_meshing: self.greedy_meshing,
             shader_based_lighting: self.shader_based_lighting,
+            cubic_chunks: self.cubic_chunks,
         }
     }
 }

--- a/server/world/generators/mesher.rs
+++ b/server/world/generators/mesher.rs
@@ -5,8 +5,8 @@ use hashbrown::{HashMap, HashSet};
 use rayon::{iter::IntoParallelIterator, prelude::ParallelIterator, ThreadPool, ThreadPoolBuilder};
 
 use crate::{
-    Chunk, GeometryProtocol, LightColor, MeshProtocol, MessageType, Registry,
-    Space, Vec2, Vec3, VoxelAccess, WorldConfig,
+    Chunk, GeometryProtocol, LightColor, MeshProtocol, MessageType, Registry, Space, Vec2, Vec3,
+    VoxelAccess, WorldConfig,
 };
 
 use super::lights::Lights;
@@ -189,9 +189,19 @@ impl Mesher {
                         let max_arr = [max.0, max.1, max.2];
 
                         let mesher_geometries = if config.greedy_meshing {
-                            voxelize_mesher::mesh_space_greedy(&min_arr, &max_arr, &space, &mesher_registry)
+                            voxelize_mesher::mesh_space_greedy(
+                                &min_arr,
+                                &max_arr,
+                                &space,
+                                &mesher_registry,
+                            )
                         } else {
-                            voxelize_mesher::mesh_space(&min_arr, &max_arr, &space, &mesher_registry)
+                            voxelize_mesher::mesh_space(
+                                &min_arr,
+                                &max_arr,
+                                &space,
+                                &mesher_registry,
+                            )
                         };
 
                         let geometries: Vec<GeometryProtocol> = mesher_geometries

--- a/server/world/voxels/chunks.rs
+++ b/server/world/voxels/chunks.rs
@@ -527,9 +527,11 @@ impl VoxelAccess for Chunks {
         false
     }
 
-    /// Get the raw light value at a voxel coordinate. If chunk not found, 0 is returned.
     fn get_raw_light(&self, vx: i32, vy: i32, vz: i32) -> u32 {
         if vy as usize >= self.config.max_height {
+            if self.config.cubic_chunks {
+                return 0;
+            }
             return LightUtils::insert_sunlight(0, self.config.max_light_level);
         }
 
@@ -552,8 +554,14 @@ impl VoxelAccess for Chunks {
         false
     }
 
-    /// Get the sunlight level at a voxel position. Returns 0 if chunk does not exist.
     fn get_sunlight(&self, vx: i32, vy: i32, vz: i32) -> u32 {
+        if self.config.cubic_chunks {
+            if let Some(chunk) = self.raw_chunk_by_voxel(vx, vy, vz) {
+                return chunk.get_sunlight(vx, vy, vz);
+            }
+            return 0;
+        }
+
         if vy >= self.config.max_height as i32 {
             return self.config.max_light_level;
         }

--- a/server/world/voxels/chunks.rs
+++ b/server/world/voxels/chunks.rs
@@ -381,6 +381,7 @@ impl Chunks {
                 sub_chunks: self.config.sub_chunks,
                 max_height: self.config.max_height,
                 max_light_level: self.config.max_light_level,
+                cubic_chunks: self.config.cubic_chunks,
             },
             needs_voxels: false,
             needs_lights: false,

--- a/server/world/voxels/chunks.rs
+++ b/server/world/voxels/chunks.rs
@@ -537,7 +537,11 @@ impl VoxelAccess for Chunks {
         }
 
         if let Some(chunk) = self.raw_chunk_by_voxel(vx, vy, vz) {
-            chunk.get_raw_light(vx, vy, vz)
+            let light = chunk.get_raw_light(vx, vy, vz);
+            if self.config.cubic_chunks {
+                return light & 0x0fff;
+            }
+            light
         } else {
             0
         }

--- a/server/world/voxels/chunks.rs
+++ b/server/world/voxels/chunks.rs
@@ -557,9 +557,6 @@ impl VoxelAccess for Chunks {
 
     fn get_sunlight(&self, vx: i32, vy: i32, vz: i32) -> u32 {
         if self.config.cubic_chunks {
-            if let Some(chunk) = self.raw_chunk_by_voxel(vx, vy, vz) {
-                return chunk.get_sunlight(vx, vy, vz);
-            }
             return 0;
         }
 

--- a/server/world/voxels/space.rs
+++ b/server/world/voxels/space.rs
@@ -428,6 +428,10 @@ impl voxelize_core::VoxelAccess for Space {
 
     fn get_all_lights(&self, vx: i32, vy: i32, vz: i32) -> (u32, u32, u32, u32) {
         let raw = VoxelAccess::get_raw_light(self, vx, vy, vz);
+        if self.options.cubic_chunks {
+            let (_, red, green, blue) = LightUtils::extract_all(raw);
+            return (0, red, green, blue);
+        }
         LightUtils::extract_all(raw)
     }
 

--- a/server/world/voxels/space.rs
+++ b/server/world/voxels/space.rs
@@ -312,7 +312,11 @@ impl VoxelAccess for Space {
                 return 0;
             }
 
-            return lights[&[lx, ly, lz]];
+            let light = lights[&[lx, ly, lz]];
+            if self.options.cubic_chunks {
+                return light & 0x0fff;
+            }
+            return light;
         }
 
         0

--- a/server/world/voxels/space.rs
+++ b/server/world/voxels/space.rs
@@ -36,6 +36,9 @@ pub struct SpaceOptions {
 
     /// Maximum light of the voxelize world.
     pub max_light_level: u32,
+
+    /// Whether this world uses cubic chunks (no sunlight).
+    pub cubic_chunks: bool,
 }
 
 /// A data structure used in Voxelize to access voxel data of multiple chunks at
@@ -294,6 +297,9 @@ impl VoxelAccess for Space {
         }
 
         if vy > 0 && vy as usize >= self.options.max_height {
+            if self.options.cubic_chunks {
+                return 0;
+            }
             return LightUtils::insert_sunlight(0, self.options.max_light_level);
         } else if vy < 0 {
             return 0;
@@ -340,6 +346,9 @@ impl VoxelAccess for Space {
     /// Get the sunlight level at the voxel position. Zero is returned if chunk doesn't exist.
     fn get_sunlight(&self, vx: i32, vy: i32, vz: i32) -> u32 {
         if !self.contains(vx, vy, vz) {
+            if self.options.cubic_chunks {
+                return 0;
+            }
             return if vy < 0 {
                 0
             } else {

--- a/server/world/voxels/space.rs
+++ b/server/world/voxels/space.rs
@@ -345,10 +345,11 @@ impl VoxelAccess for Space {
 
     /// Get the sunlight level at the voxel position. Zero is returned if chunk doesn't exist.
     fn get_sunlight(&self, vx: i32, vy: i32, vz: i32) -> u32 {
+        if self.options.cubic_chunks {
+            return 0;
+        }
+
         if !self.contains(vx, vy, vz) {
-            if self.options.cubic_chunks {
-                return 0;
-            }
             return if vy < 0 {
                 0
             } else {


### PR DESCRIPTION
Add `cubic_chunks` world config to disable sunlight propagation in cubic chunk worlds.

---
<a href="https://cursor.com/background-agent?bcId=bc-48736e15-8740-4784-8d7f-22188fa9c538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-48736e15-8740-4784-8d7f-22188fa9c538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

