### PR TITLE
fix: memory leak when chunks are unloaded

### DIFF
--- a/packages/core/src/core/world/chunk.ts
+++ b/packages/core/src/core/world/chunk.ts
@@ -54,5 +54,9 @@ export class Chunk extends RawChunk {
         }
       });
     });
+    this.meshes.clear();
+    // Release large typed arrays for GC
+    this.voxels.data = new Uint32Array(0);
+    this.lights.data = new Uint32Array(0);
   }
 }

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -3956,6 +3956,7 @@ export class World<T = any> extends Scene implements NetIntercept {
         });
 
         this.pruneBlockEntitiesInChunk(chunk.coords);
+        this.remove(chunk.group);
         chunk.dispose();
         this.meshPipeline.remove(x, z);
         toRemove.push(name);


### PR DESCRIPTION
## Summary
- Remove chunk.group from scene before disposing
- Clear meshes Map and release voxel/light typed arrays in dispose()

## Problem
When traveling through a world with many chunks, memory grows unboundedly (causing ~4GB OOM when traversing areas with ~400K blocks) because:
1. `chunk.group` was never removed from the scene (`this.remove()`) - only children were disposed
2. Large typed arrays (`voxels.data`, `lights.data` ~512KB per chunk) were not released

## Changes
- **index.ts**: Add `this.remove(chunk.group)` before `chunk.dispose()` in `maintainChunks()`
- **chunk.ts**: Clear `meshes` Map and release typed arrays in `dispose()`
