### PR TITLE
Add nal-trace to .cursor/.gitignore

### DIFF
--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -1,0 +1,1 @@
+nal-trace/


### PR DESCRIPTION
Adds nal-trace/ to .cursor/.gitignore to exclude trace files from version control.

Made with [Cursor](https://cursor.com)