### PR TITLE
docs: add balta section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,7 @@ If you like our work, please consider supporting us on Patreon, BuyMeACoffee, or
 
 - [Connection Serif Font (SIL Open Font)](https://fonts2u.com/connection-serif.font)
 - [Pixel Perfection by XSSheep (CC BY-SA 4.0)](https://www.planetminecraft.com/texture-pack/131pixel-perfection/)
+
+## balta
+
+balta


### PR DESCRIPTION
Adds a short **balta** section at the end of the README.


Made with [Cursor](https://cursor.com)