### PR TITLE
voxelize: speed up local release builds + devex

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,17 @@
+# Shared cargo configuration. Keep all rustflags here rather than in
+# per-command RUSTFLAGS environment variables: cargo fingerprints builds by
+# their flags, so two invocations with different RUSTFLAGS silently invalidate
+# each other's cache and force full rebuilds.
+
+[build]
+# Opt-in: shared compilation cache across checkouts (e.g. this repo and a
+# parent project consuming it as a submodule). Requires `cargo install sccache`.
+# rustc-wrapper = "sccache"
+
+# Faster linking: Rust >= 1.90 already links with the bundled rust-lld on
+# x86_64-unknown-linux-gnu. On other platforms, install lld (apt install lld /
+# brew install llvm) and opt in below.
+# [target.aarch64-unknown-linux-gnu]
+# rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+# [target.aarch64-apple-darwin]
+# rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,5 +97,14 @@ harness = false
 opt-level = 3
 debug = 2
 
+# Local iteration profile: same opt-level (and therefore the same runtime
+# performance) as `release`, but rebuilds are incremental and only line-table
+# debug info is emitted, which cuts edit-rebuild times dramatically.
+# Use with `cargo run --profile release-dev --example demo` (what `pnpm demo:rs` does).
+[profile.release-dev]
+inherits = "release"
+incremental = true
+debug = "line-tables-only"
+
 [profile.bench]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ pnpm run demo
 
 visit http://localhost:3000
 
+### Faster local builds
+
+- The server watch loop (`pnpm demo:rs`) builds with the `release-dev` profile: the same `opt-level = 3` runtime performance as `release`, but with incremental compilation and minimal debug info for much faster edit-rebuild cycles. Use it manually with `cargo run --profile release-dev --example demo`. Published/production builds should keep using `--release`.
+- If you consume Voxelize as a submodule of a parent cargo workspace, cargo takes profiles from the parent's root `Cargo.toml` — copy the `[profile.release-dev]` block there to get the same fast iteration.
+- Rust >= 1.90 links with the fast bundled `rust-lld` on x86_64 Linux out of the box; see `.cargo/config.toml` for opt-in lld linking on other platforms and an opt-in `sccache` shared cache.
+
 ## Supporting
 
 If you like our work, please consider supporting us on Patreon, BuyMeACoffee, or PayPal. Thanks a lot!

--- a/crates/wasm-mesher/Cargo.toml
+++ b/crates/wasm-mesher/Cargo.toml
@@ -18,3 +18,9 @@ serde-wasm-bindgen = "0.6"
 [profile.release]
 opt-level = 3
 lto = true
+
+# `wasm-pack build --dev` (the watch loop) compiles this profile. opt-level 1
+# keeps rebuilds fast and incremental while making the meshing hot loops
+# usable in the browser, unlike the default opt-level 0.
+[profile.dev]
+opt-level = 1

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:wasm:release": "cd crates/wasm-mesher && wasm-pack build --target web --release",
     "build": "pnpm build:wasm && cd packages && pnpm -r --workspace-concurrency=1 --filter \"@voxelize/*\" --filter \"!@voxelize/core\" build && cd core && pnpm build",
     "demo:ts": "cd examples/client && pnpm demo",
-    "demo:rs": "cross-env RUST_BACKTRACE=1 cargo watch -w examples/server -w server -x \"run --release --example demo\"",
+    "demo:rs": "cross-env RUST_BACKTRACE=1 cargo watch -w examples/server -w server -x \"run --profile release-dev --example demo\"",
     "test-dev": "vitest",
     "test": "vitest --run",
     "test:rust": "cargo test --test mesher_tests --test lights_tests",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# The dependency graph requires Rust >= 1.85 (edition 2024 crates), and
+# stable >= 1.90 links with the fast bundled rust-lld on x86_64 Linux.
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves local developer experience by making release-optimized iteration builds rebuild much faster, without giving up release-level runtime performance. Production builds (`--release`) are untouched.

### Changes and rationale

- **`[profile.release-dev]` in `Cargo.toml`**: inherits `release` (same `opt-level = 3` and codegen-units, so identical runtime performance), but enables incremental compilation and emits only line-table debug info instead of full debuginfo. The release profile's `debug = 2` plus non-incremental compilation was the main rebuild-time cost; the release profile keeps full debuginfo for profiling/flamegraph work.
- **`package.json` `demo:rs`**: the server watch loop now builds with `--profile release-dev` instead of `--release`, so every save in the `cargo watch` loop benefits.
- **`.cargo/config.toml`**: central home for rustflags so every cargo invocation sees identical flags — mismatched per-command `RUSTFLAGS` silently invalidates the build cache and forces full rebuilds. Includes documented opt-ins for `sccache` (shared compile cache across checkouts, e.g. this repo and a parent project's submodule) and lld linking on platforms where it is not the default.
- **`rust-toolchain.toml`** with `channel = "stable"`: the dependency graph already requires Rust >= 1.85 (edition-2024 crates; cargo 1.83 fails to even resolve), and stable >= 1.90 links with the bundled `rust-lld` on x86_64 Linux out of the box — fast linking with no system dependency to install.
- **`crates/wasm-mesher/Cargo.toml`**: the wasm watch loop (`wasm-pack build --dev`) now compiles at `opt-level = 1` — rebuilds stay incremental and sub-second, but the meshing hot loops are actually usable in the browser unlike default `opt-level = 0`. The published wasm build keeps `opt-level = 3` + fat LTO.
- **README**: documents the workflow, including that a parent cargo workspace consuming Voxelize as a submodule takes profiles from its own root `Cargo.toml` — copy the `[profile.release-dev]` block there to get the same speedup in that setup.

### Measured (8-core Linux, rustc 1.96 stable)

| Scenario | `--release` (before) | `--profile release-dev` |
| --- | --- | --- |
| Full build of `--example demo` | 1m 32s | 1m 11s |
| Rebuild after editing `server/lib.rs` | 23.9s | 2.5s (~9.6x) |
| Rebuild after editing `server/world/mod.rs` | ~24s | 4.9s (~4.9x) |
| wasm dev rebuild after editing `crates/mesher` | — | 0.45s |

Runtime verified: `cargo run --profile release-dev --example demo` boots, preloads worlds, and serves `GET /info` with HTTP 200, identically to the `--release` binary. (A pre-existing `No such system registered ("physics")` panic in the demo's `test` world reproduces identically on the unmodified `--release` build — unrelated to this PR.)

Benchmark log: [build_benchmarks.log](https://cursor.com/artifacts/c/art-65cd5bd3-3867-4618-a952-e5012d2511c8)

### Usage

```bash
pnpm demo:rs                                      # now uses release-dev automatically
cargo run --profile release-dev --example demo    # manual
cargo build --release                             # production, unchanged
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aca865ec-b7f7-402c-9785-9f263fb7b8ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aca865ec-b7f7-402c-9785-9f263fb7b8ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

