### PR TITLE
perf(lighting): slash per-voxel overhead in propagate/flood_light (constant-factor, bit-identical)

### DIFF
--- a/server/world/generators/lights.rs
+++ b/server/world/generators/lights.rs
@@ -61,14 +61,18 @@ impl Lights {
             }
 
             let [vx, vy, vz] = voxel;
-            let source_block = registry.get_block_by_id(space.get_voxel(vx, vy, vz));
-            let voxel_pos = Vec3(vx, vy, vz);
-            let source_transparency = if !is_sunlight
-                && source_block.get_torch_light_level_at(&voxel_pos, space, color) > 0
-            {
+            let (source_id, source_rotation) = space.get_voxel_and_rotation(vx, vy, vz);
+            let source_block = registry.get_block_by_id(source_id);
+            // The torch-emission override only applies to emitters; skipping the
+            // per-voxel dynamic light lookup for the common non-emitting source is
+            // equivalent because such blocks always report a torch level of zero.
+            let is_source_emitting = !is_sunlight
+                && (source_block.is_light || source_block.dynamic_patterns.is_some())
+                && source_block.get_torch_light_level_at(&Vec3(vx, vy, vz), space, color) > 0;
+            let source_transparency = if is_source_emitting {
                 ALL_TRANSPARENT
             } else {
-                source_block.get_rotated_transparency(&space.get_voxel_rotation(vx, vy, vz))
+                source_block.get_rotated_transparency(&source_rotation)
             };
 
             for [ox, oy, oz] in &VOXEL_NEIGHBORS {
@@ -105,9 +109,9 @@ impl Lights {
                 }
 
                 let next_voxel = [nvx, nvy, nvz];
-                let n_block = registry.get_block_by_id(space.get_voxel(nvx, nvy, nvz));
-                let rotation = space.get_voxel_rotation(nvx, nvy, nvz);
-                let n_transparency = n_block.get_rotated_transparency(&rotation);
+                let (n_id, n_rotation) = space.get_voxel_and_rotation(nvx, nvy, nvz);
+                let n_block = registry.get_block_by_id(n_id);
+                let n_transparency = n_block.get_rotated_transparency(&n_rotation);
                 let reduce = if is_sunlight
                     && !n_block.light_reduce
                     && *oy == -1
@@ -326,9 +330,8 @@ impl Lights {
         for y in (0..=region_top).rev() {
             for x in 0..shape.0 {
                 for z in 0..shape.2 {
-                    let id = space.get_voxel(x + start_x, y, z + start_z);
+                    let (id, rotation) = space.get_voxel_and_rotation(x + start_x, y, z + start_z);
                     let block = registry.get_block_by_id(id);
-                    let voxel_pos = Vec3(x + start_x, y, z + start_z);
 
                     let &Block {
                         is_transparent,
@@ -338,13 +341,29 @@ impl Lights {
                         ..
                     } = block;
 
-                    // Get dynamic light levels
-                    let red_light_level =
-                        block.get_torch_light_level_at(&voxel_pos, space, &LightColor::Red);
-                    let green_light_level =
-                        block.get_torch_light_level_at(&voxel_pos, space, &LightColor::Green);
-                    let blue_light_level =
-                        block.get_torch_light_level_at(&voxel_pos, space, &LightColor::Blue);
+                    // Torch levels only vary per-voxel for dynamic blocks; for the
+                    // common static block the registry fields already hold the exact
+                    // values `get_torch_light_level_at` would return, so read them
+                    // directly and skip three dynamic-pattern lookups per voxel.
+                    let (red_light_level, green_light_level, blue_light_level) =
+                        if block.dynamic_patterns.is_some() {
+                            let voxel_pos = Vec3(x + start_x, y, z + start_z);
+                            (
+                                block.get_torch_light_level_at(&voxel_pos, space, &LightColor::Red),
+                                block.get_torch_light_level_at(
+                                    &voxel_pos,
+                                    space,
+                                    &LightColor::Green,
+                                ),
+                                block.get_torch_light_level_at(&voxel_pos, space, &LightColor::Blue),
+                            )
+                        } else {
+                            (
+                                block.red_light_level,
+                                block.green_light_level,
+                                block.blue_light_level,
+                            )
+                        };
 
                     if is_light
                         || red_light_level > 0
@@ -376,9 +395,7 @@ impl Lights {
 
                     let index = (x + z * shape.0) as usize;
 
-                    let [px, py, pz, nx, ny, nz] = space
-                        .get_voxel_rotation(x + start_x, y, z + start_z)
-                        .rotate_transparency(is_transparent);
+                    let [px, py, pz, nx, ny, nz] = rotation.rotate_transparency(is_transparent);
 
                     if is_opaque {
                         mask[index] = 0;

--- a/server/world/voxels/access.rs
+++ b/server/world/voxels/access.rs
@@ -42,6 +42,17 @@ pub trait VoxelAccess {
         self.set_raw_voxel(vx, vy, vz, value)
     }
 
+    /// Fetch the voxel id and rotation together. Both are encoded in the same raw
+    /// voxel word, so implementations backed by a single lookup can resolve the
+    /// coordinate once instead of paying for two independent accesses in the
+    /// lighting hot loops. The default mirrors calling the two getters separately.
+    fn get_voxel_and_rotation(&self, vx: i32, vy: i32, vz: i32) -> (u32, BlockRotation) {
+        (
+            self.get_voxel(vx, vy, vz),
+            self.get_voxel_rotation(vx, vy, vz),
+        )
+    }
+
     fn get_voxel_stage(&self, vx: i32, vy: i32, vz: i32) -> u32 {
         BlockUtils::extract_stage(self.get_raw_voxel(vx, vy, vz))
     }

--- a/server/world/voxels/space.rs
+++ b/server/world/voxels/space.rs
@@ -75,13 +75,21 @@ pub struct Space {
 
 impl Space {
     /// Converts a voxel position to a chunk coordinate and a chunk local coordinate.
+    ///
+    /// `map_voxel_to_chunk_local` would recompute the chunk coordinate internally,
+    /// so derive the local coordinate from the chunk coordinate directly to avoid
+    /// resolving the (float) chunk mapping twice on every voxel access.
     fn to_local(&self, vx: i32, vy: i32, vz: i32) -> (Vec2<i32>, Vec3<usize>) {
-        let SpaceOptions { chunk_size, .. } = self.options;
+        let chunk_size = self.options.chunk_size as i32;
 
-        let coords = ChunkUtils::map_voxel_to_chunk(vx, vy, vz, chunk_size);
-        let local = ChunkUtils::map_voxel_to_chunk_local(vx, vy, vz, chunk_size);
+        let Vec2(cx, cz) = ChunkUtils::map_voxel_to_chunk(vx, vy, vz, self.options.chunk_size);
+        let local = Vec3(
+            (vx - cx * chunk_size) as usize,
+            vy as usize,
+            (vz - cz * chunk_size) as usize,
+        );
 
-        (coords, local)
+        (Vec2(cx, cz), local)
     }
 }
 
@@ -274,6 +282,18 @@ impl VoxelAccess for Space {
         }
 
         BlockUtils::extract_rotation(self.get_raw_voxel(vx, vy, vz))
+    }
+
+    /// Get the voxel id and rotation in a single lookup. Equivalent to calling
+    /// `get_voxel` and `get_voxel_rotation`, but resolves the chunk coordinate and
+    /// reads the raw voxel word once instead of twice.
+    fn get_voxel_and_rotation(&self, vx: i32, vy: i32, vz: i32) -> (u32, BlockRotation) {
+        if !self.contains(vx, vy, vz) {
+            return (0, BlockRotation::encode(PY_ROTATION, 0));
+        }
+
+        let raw = self.get_raw_voxel(vx, vy, vz);
+        (BlockUtils::extract_id(raw), BlockUtils::extract_rotation(raw))
     }
 
     /// Get the voxel stage at the voxel position. Zero is returned if chunk doesn't exist.

--- a/tests/lights_load_path_golden.rs
+++ b/tests/lights_load_path_golden.rs
@@ -1,0 +1,274 @@
+use std::collections::hash_map::DefaultHasher;
+use std::collections::VecDeque;
+use std::hash::{Hash, Hasher};
+
+use voxelize::{
+    Block, Chunk, ChunkOptions, Chunks, LightColor, Lights, Registry, Vec2, Vec3, VoxelAccess,
+    WorldConfig,
+};
+
+const AIR: u32 = 0;
+const STONE: u32 = 1;
+const GLASS: u32 = 2;
+const LEAVES: u32 = 3;
+const TORCH_R: u32 = 4;
+const TORCH_G: u32 = 5;
+const TORCH_B: u32 = 6;
+const TORCH_RGB: u32 = 7;
+
+const CHUNK_SIZE: usize = 16;
+const MAX_HEIGHT: usize = 128;
+const SUB_CHUNKS: usize = 8;
+
+// Golden hash of the full propagated + flooded light state over the 3x3
+// neighborhood produced by the mesher load path. Captured from the algorithm
+// before the per-voxel overhead optimizations; any divergence means the output
+// changed.
+const EXPECTED_HASH: u64 = 2331721970131544895;
+
+fn create_registry() -> Registry {
+    let mut registry = Registry::new();
+
+    registry.register_block(&Block::new("stone").id(STONE).build());
+    registry.register_block(&Block::new("glass").id(GLASS).is_transparent(true).build());
+    registry.register_block(
+        &Block::new("leaves")
+            .id(LEAVES)
+            .is_transparent(true)
+            .light_reduce(true)
+            .build(),
+    );
+    registry.register_block(
+        &Block::new("torch_r")
+            .id(TORCH_R)
+            .is_passable(true)
+            .is_transparent(true)
+            .red_light_level(14)
+            .build(),
+    );
+    registry.register_block(
+        &Block::new("torch_g")
+            .id(TORCH_G)
+            .is_passable(true)
+            .is_transparent(true)
+            .green_light_level(13)
+            .build(),
+    );
+    registry.register_block(
+        &Block::new("torch_b")
+            .id(TORCH_B)
+            .is_passable(true)
+            .is_transparent(true)
+            .blue_light_level(9)
+            .build(),
+    );
+    registry.register_block(
+        &Block::new("torch_rgb")
+            .id(TORCH_RGB)
+            .is_passable(true)
+            .is_transparent(true)
+            .red_light_level(15)
+            .green_light_level(11)
+            .blue_light_level(7)
+            .build(),
+    );
+
+    registry
+}
+
+/// Deterministic terrain that is continuous across chunk seams (a pure function
+/// of world coordinates), with varied heights, transparent and light-reducing
+/// surface cover, a floating overhang, a tall pillar, caves, and torches.
+fn world_block(vx: i32, vy: i32, vz: i32) -> u32 {
+    let base = 20 + (vx * 7 + vz * 13).rem_euclid(15);
+
+    // Tall pillar to exercise vertical sunlight occlusion across many rows.
+    if vx == 4 && vz == 4 && vy <= 90 {
+        return STONE;
+    }
+
+    // Floating overhang slab: covers a patch, leaving sheltered air beneath it.
+    if (6..11).contains(&vx) && (6..11).contains(&vz) && vy == 40 {
+        return STONE;
+    }
+
+    if vy <= base {
+        // Carve a horizontal cave tunnel through the solid ground.
+        if vy == base - 4 && (-3..12).contains(&vx) {
+            // Place a few colored torches inside the tunnel.
+            if vx.rem_euclid(5) == 0 && vz.rem_euclid(4) == 0 {
+                return match (vx + vz).rem_euclid(4) {
+                    0 => TORCH_R,
+                    1 => TORCH_G,
+                    2 => TORCH_B,
+                    _ => TORCH_RGB,
+                };
+            }
+            return AIR;
+        }
+        return STONE;
+    }
+
+    // Surface cover one block above the ground: glass and leaves in patches.
+    if vy == base + 1 {
+        let patch = (vx.rem_euclid(6), vz.rem_euclid(6));
+        if patch.0 < 2 {
+            return GLASS;
+        } else if (2..4).contains(&patch.0) {
+            return LEAVES;
+        }
+    }
+
+    // A surface torch sitting out in the open sky.
+    if vy == base + 2 && vx.rem_euclid(8) == 3 && vz.rem_euclid(8) == 5 {
+        return TORCH_RGB;
+    }
+
+    AIR
+}
+
+fn build_chunk(cx: i32, cz: i32, registry: &Registry) -> Chunk {
+    let opts = ChunkOptions {
+        size: CHUNK_SIZE,
+        max_height: MAX_HEIGHT,
+        sub_chunks: SUB_CHUNKS,
+    };
+    let mut chunk = Chunk::new("golden", cx, cz, &opts);
+
+    let min_x = cx * CHUNK_SIZE as i32;
+    let min_z = cz * CHUNK_SIZE as i32;
+
+    for lx in 0..CHUNK_SIZE as i32 {
+        for lz in 0..CHUNK_SIZE as i32 {
+            let vx = min_x + lx;
+            let vz = min_z + lz;
+            for vy in 0..MAX_HEIGHT as i32 {
+                let id = world_block(vx, vy, vz);
+                if id != AIR {
+                    chunk.set_voxel(vx, vy, vz, id);
+                }
+            }
+        }
+    }
+
+    chunk.calculate_max_height(registry);
+    chunk
+}
+
+/// Replicates `Mesher::process` load path for the center chunk: propagate over
+/// the full 3x3 neighborhood, then flood the accumulated queues, returning the
+/// space so the resulting light arrays can be snapshotted.
+fn run_load_path(config: &WorldConfig, registry: &Registry) -> voxelize::Space {
+    let mut chunks = Chunks::new(config);
+
+    for cx in -1..=1 {
+        for cz in -1..=1 {
+            chunks.add(build_chunk(cx, cz, registry));
+        }
+    }
+
+    let coords = Vec2(0, 0);
+    let chunk_size = config.chunk_size as i32;
+
+    let mut space = chunks
+        .make_space(&coords, config.max_light_level as usize)
+        .needs_voxels()
+        .needs_lights()
+        .needs_height_maps()
+        .build();
+
+    let min = space.min.to_owned();
+    let shape = space.shape.to_owned();
+
+    let light_colors = [
+        LightColor::Sunlight,
+        LightColor::Red,
+        LightColor::Green,
+        LightColor::Blue,
+    ];
+
+    let mut light_queues = vec![VecDeque::new(); 4];
+
+    for dx in -1..=1 {
+        for dz in -1..=1 {
+            let sub_min = Vec3(
+                (coords.0 + dx) * chunk_size - if dx == 0 && dz == 0 { 1 } else { 0 },
+                0,
+                (coords.1 + dz) * chunk_size - if dx == 0 && dz == 0 { 1 } else { 0 },
+            );
+            let sub_shape = Vec3(
+                chunk_size as usize + if dx == 0 && dz == 0 { 2 } else { 0 },
+                MAX_HEIGHT,
+                chunk_size as usize + if dx == 0 && dz == 0 { 2 } else { 0 },
+            );
+
+            let subqueues = Lights::propagate(&mut space, &sub_min, &sub_shape, registry, config);
+
+            for (queue, subqueue) in light_queues.iter_mut().zip(subqueues.into_iter()) {
+                queue.extend(subqueue);
+            }
+        }
+    }
+
+    for (queue, color) in light_queues.into_iter().zip(light_colors.iter()) {
+        if !queue.is_empty() {
+            Lights::flood_light(
+                &mut space,
+                queue,
+                color,
+                registry,
+                config,
+                Some(&min),
+                Some(&shape),
+            );
+        }
+    }
+
+    space
+}
+
+fn hash_lights(space: &voxelize::Space, hasher: &mut DefaultHasher) {
+    for cx in -1..=1 {
+        for cz in -1..=1 {
+            let lights = space
+                .get_lights(cx, cz)
+                .expect("space should contain loaded chunk lights");
+            lights.data.hash(hasher);
+        }
+    }
+}
+
+#[test]
+fn load_path_light_output_is_stable() {
+    let config = WorldConfig {
+        chunk_size: CHUNK_SIZE,
+        max_height: MAX_HEIGHT,
+        max_light_level: 15,
+        sub_chunks: SUB_CHUNKS,
+        min_chunk: [-1, -1],
+        max_chunk: [1, 1],
+        ..Default::default()
+    };
+
+    let registry = create_registry();
+
+    let space = run_load_path(&config, &registry);
+
+    let mut hasher = DefaultHasher::new();
+    hash_lights(&space, &mut hasher);
+    let hash = hasher.finish();
+
+    println!("load-path light golden hash = {hash}");
+
+    // Sanity: lighting actually ran (some non-zero light exists in the center).
+    let center = space.get_lights(0, 0).unwrap();
+    assert!(
+        center.data.iter().any(|&l| l != 0),
+        "center chunk has no light; fixture or load path is broken"
+    );
+
+    assert_eq!(
+        hash, EXPECTED_HASH,
+        "load-path light output changed; expected {EXPECTED_HASH}, got {hash}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Angle (Attempt 2): slash per-voxel overhead in the hot loops

This keeps the lighting algorithm shape identical and makes `propagate`/`flood_light` dramatically cheaper *per voxel*. Pure constant-factor wins, bit-for-bit identical output. It does **not** re-touch the already-merged empty-sky/heightmap optimization — it builds on top of it.

## Bottleneck targeted

Profiling the load path (`client_only_meshing = true`, so the server "mesher" does lighting only) showed the cost is dominated by per-voxel access overhead in the BFS/seed loops, not algorithmic work:

- Every `Space::get_voxel` / `get_voxel_rotation` / `get_*_light` resolves the chunk coordinate via `Space::to_local`, which called `ChunkUtils::map_voxel_to_chunk` **twice** (once directly, once inside `map_voxel_to_chunk_local`) — float multiply + floor + cast per axis, on every single access.
- In `flood_light`, each neighbor fetched the **same raw voxel word twice**: once through `get_voxel` (id) and again through `get_voxel_rotation` (rotation), doubling the coordinate resolution + hashmap lookup + `contains` checks.
- `propagate` did the same double-fetch (id then rotation) per voxel, and called `Block::get_torch_light_level_at` **three times per voxel** (R/G/B) even for the overwhelmingly common non-emitting, non-dynamic blocks, each walking the dynamic-pattern `Option`.

## Approach

- `Space::to_local`: resolve the chunk coordinate once and derive the local coordinate from it (drops the duplicate `map_voxel_to_chunk`). Speeds up every voxel/light get/set.
- New `VoxelAccess::get_voxel_and_rotation` that returns id + rotation from a single lookup. The trait default just calls the two existing getters (so the `Chunks` update path is byte-for-byte unchanged); `Space` overrides it to resolve the coordinate and read the raw voxel word once, exactly matching `get_voxel` + `get_voxel_rotation` semantics (same `contains` guard, same `PY` default).
- `flood_light`: use `get_voxel_and_rotation` for both source and neighbor; skip the source torch-emission lookup for blocks that statically cannot emit (`!is_light && dynamic_patterns.is_none()` always reports a torch level of 0).
- `propagate`: use `get_voxel_and_rotation` (reuse the rotation already fetched for the transparency mask), and read R/G/B torch levels straight from the registry fields for non-dynamic blocks (identical to what `get_torch_light_level_at` returns), only falling back to the dynamic-pattern path when the block actually has dynamic patterns.

No public protocol/client changes; no unrelated refactors.

## Proof of unchanged output (golden hashes)

- Existing `tests/lights_propagate_equivalence.rs` (terrain with opaque/transparent/light_reduce blocks, torches, pillars, varied heights): hash `15060725151583092294` — **unchanged**.
- New `tests/lights_load_path_golden.rs`: faithfully replicates `Mesher::process` load path (3x3 neighborhood `propagate` + accumulated `flood_light`) across a 3x3 chunk grid with seams, a floating overhang, a tall pillar, cave tunnels with R/G/B torches, transparent + light-reducing surface cover, and empty sky. It hashes the full sunlight+RGB light arrays of all loaded chunks. Hash `2331721970131544895` — captured on the pre-optimization algorithm and **unchanged** after the optimization.

## Measured speedup

`cargo bench --bench lights_bench` (pure BFS spread, the dominant load-path cost):

| bench | before | after |
| --- | --- | --- |
| `flood_sunlight_16x64x16` | 6.38 ms | 5.07 ms (~1.26x) |
| `propagate_sunlight_16x64x16` | 2.12 ms | 2.12 ms |

The shipped `propagate` bench runs on an *empty* chunk, so it's dominated by the sky-fill (untouched here) rather than the seed scan; it's flat. To measure the realistic pipeline I ran a controlled before/after timing of the full load-path fixture (same terrain as the golden test; terrain construction excluded from timing; throwaway harness, not committed):

- before: **53.9 ms** / load
- after: **42.4 ms** / load  → **~1.27x** faster

## Testing

- ✅ `cargo build`
- ✅ `cargo test` (all suites green)
- ✅ `cargo test --test lights_load_path_golden` (new golden, hash unchanged)
- ✅ `cargo test --test lights_propagate_equivalence` (existing golden, hash unchanged)
- ✅ `cargo bench --bench lights_bench`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98560ce4-630f-429e-859c-4e81e4f8d761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98560ce4-630f-429e-859c-4e81e4f8d761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

