### PR TITLE
Fix ~400% idle CPU: gate per-tick parallel dispatch when world is idle

### DIFF
--- a/server/server/mod.rs
+++ b/server/server/mod.rs
@@ -206,6 +206,10 @@ pub struct Server {
     /// Worlds with a tick already queued or running.
     pending_world_ticks: HashSet<String>,
 
+    /// Worlds whose actor has stopped responding; these are no longer ticked
+    /// to avoid spamming mailbox errors and burning a core on a dead world.
+    dead_worlds: HashSet<String>,
+
     /// The information sent to the client when requested.
     info_handle: ServerInfoHandle,
 
@@ -607,7 +611,7 @@ impl Actor for Server {
                 .worlds
                 .iter()
                 .filter_map(|(name, world)| {
-                    if act.pending_world_ticks.contains(name) {
+                    if act.pending_world_ticks.contains(name) || act.dead_worlds.contains(name) {
                         None
                     } else {
                         Some((name.clone(), world.clone()))
@@ -621,7 +625,15 @@ impl Actor for Server {
                     wrap_future(world.send(Tick)).map(move |result, act: &mut Server, _| {
                         act.pending_world_ticks.remove(&world_name);
                         if let Err(error) = result {
-                            warn!("World tick failed for {}: {:?}", world_name, error);
+                            // The world actor's mailbox is closed (stopped or
+                            // panicked). Stop ticking it so we don't spam mailbox
+                            // errors and waste a core re-sending to a dead world.
+                            if act.dead_worlds.insert(world_name.clone()) {
+                                warn!(
+                                    "World tick failed for {}: {:?}. No longer ticking this world.",
+                                    world_name, error
+                                );
+                            }
                         }
                     }),
                 );
@@ -858,6 +870,7 @@ impl ServerBuilder {
             lost_sessions: HashMap::default(),
             transport_sessions: HashMap::default(),
             pending_world_ticks: HashSet::default(),
+            dead_worlds: HashSet::default(),
             worlds: HashMap::default(),
             info_handle: default_info_handle,
             action_handles: HashMap::default(),

--- a/server/world/generators/mesher.rs
+++ b/server/world/generators/mesher.rs
@@ -69,6 +69,10 @@ impl Mesher {
         self.queue.pop_front()
     }
 
+    pub fn is_idle(&self) -> bool {
+        self.queue.is_empty() && self.map.is_empty() && self.pending_remesh.is_empty()
+    }
+
     pub fn mark_for_remesh(&mut self, coords: &Vec2<i32>) {
         if self.map.contains(coords) {
             self.pending_remesh.insert(coords.to_owned());

--- a/server/world/generators/pipeline.rs
+++ b/server/world/generators/pipeline.rs
@@ -3,7 +3,6 @@ use std::{collections::VecDeque, sync::Arc};
 use crossbeam_channel::{unbounded, Receiver, Sender, TryRecvError};
 use hashbrown::{HashMap, HashSet};
 use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
-use rayon::{ThreadPool, ThreadPoolBuilder};
 
 use crate::{
     Chunk, ChunkStatus, Registry, Space, SpaceData, Terrain, Vec2, Vec3, VoxelAccess, VoxelUpdate,
@@ -226,9 +225,6 @@ pub struct Pipeline {
 
     /// Receiver to receive processed chunks from other threads to main thread.
     receiver: Arc<Receiver<(Chunk, Vec<VoxelUpdate>)>>,
-
-    /// Pipeline's thread pool to process chunks.
-    pool: ThreadPool,
 }
 
 impl Pipeline {
@@ -239,10 +235,6 @@ impl Pipeline {
         Self {
             sender: Arc::new(sender),
             receiver: Arc::new(receiver),
-            pool: ThreadPoolBuilder::new()
-                .thread_name(|index| format!("voxelize-chunking-{index}"))
-                .build()
-                .unwrap(),
             chunks: HashSet::new(),
             leftovers: HashMap::new(),
             pending_regenerate: HashSet::new(),

--- a/server/world/generators/pipeline.rs
+++ b/server/world/generators/pipeline.rs
@@ -293,6 +293,10 @@ impl Pipeline {
         self.queue.pop_front()
     }
 
+    pub fn is_idle(&self) -> bool {
+        self.queue.is_empty() && self.chunks.is_empty() && self.pending_regenerate.is_empty()
+    }
+
     /// Add a stage to the chunking pipeline.
     pub fn add_stage<T>(&mut self, stage: T)
     where

--- a/server/world/messages.rs
+++ b/server/world/messages.rs
@@ -31,6 +31,10 @@ impl MessageQueues {
         (self.critical.len(), self.normal.len(), self.bulk.len())
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.critical.is_empty() && self.normal.is_empty() && self.bulk.is_empty()
+    }
+
     pub fn push(&mut self, item: (Message, ClientFilter)) {
         let (message, filter) = item;
         match MessageType::try_from(message.r#type) {
@@ -81,6 +85,10 @@ impl EncodedMessageQueue {
 
     pub fn queue_stats(&self) -> (usize, usize) {
         (self.pending.len(), self.processed.len())
+    }
+
+    pub fn is_idle(&self) -> bool {
+        self.pending.is_empty() && self.processed.is_empty() && self.receiver.is_empty()
     }
 
     pub fn append(&mut self, mut list: Vec<(Message, ClientFilter)>) {

--- a/server/world/mod.rs
+++ b/server/world/mod.rs
@@ -1604,6 +1604,48 @@ impl World {
         self.preloading = true;
     }
 
+    fn is_idle(&self) -> bool {
+        if self.preloading {
+            return false;
+        }
+
+        if !self.clients().is_empty() {
+            return false;
+        }
+
+        if !self.read_resource::<Transports>().is_empty() {
+            return false;
+        }
+
+        if !self.pipeline().is_idle() {
+            return false;
+        }
+
+        if !self.mesher().is_idle() {
+            return false;
+        }
+
+        if !self.chunks().is_idle() {
+            return false;
+        }
+
+        if !self.events().queue.is_empty() {
+            return false;
+        }
+
+        if !self.read_resource::<MessageQueues>().is_empty() {
+            return false;
+        }
+
+        if !self.read_resource::<EncodedMessageQueue>().is_idle() {
+            return false;
+        }
+
+        // Any live entity (player body, mob, item, block entity, ...) needs the
+        // per-tick simulation and metadata systems to keep running.
+        self.ecs.entities().join().count() == 0
+    }
+
     /// Tick of the world, run every 16ms.
     pub(crate) fn tick(&mut self) {
         if !self.started {
@@ -1651,25 +1693,31 @@ impl World {
 
         let tick_timer = SystemTimer::new("tick-total");
 
-        let dispatch_time = {
-            let mut dispatcher_guard = self.built_dispatcher.lock().unwrap();
-            if dispatcher_guard.is_none() {
-                let build_timer = SystemTimer::new("dispatcher-build");
-                let dispatcher = (self.dispatcher)().build();
-                *dispatcher_guard = Some(UnsafeSendSync::new(dispatcher));
-                record_timing(&self.name, "dispatcher-build", build_timer.elapsed_ms());
-            }
+        let dispatch_time = if self.is_idle() {
+            0.0
+        } else {
+            let dispatch_time = {
+                let mut dispatcher_guard = self.built_dispatcher.lock().unwrap();
+                if dispatcher_guard.is_none() {
+                    let build_timer = SystemTimer::new("dispatcher-build");
+                    let dispatcher = (self.dispatcher)().build();
+                    *dispatcher_guard = Some(UnsafeSendSync::new(dispatcher));
+                    record_timing(&self.name, "dispatcher-build", build_timer.elapsed_ms());
+                }
 
-            let dispatch_timer = SystemTimer::new("dispatcher-dispatch");
-            dispatcher_guard
-                .as_mut()
-                .unwrap()
-                .get_mut()
-                .dispatch(&self.ecs);
-            dispatch_timer.elapsed_ms()
+                let dispatch_timer = SystemTimer::new("dispatcher-dispatch");
+                dispatcher_guard
+                    .as_mut()
+                    .unwrap()
+                    .get_mut()
+                    .dispatch(&self.ecs);
+                dispatch_timer.elapsed_ms()
+            };
+
+            self.write_resource::<Profiler>().summarize();
+
+            dispatch_time
         };
-
-        self.write_resource::<Profiler>().summarize();
 
         let maintain_time = {
             let maintain_timer = SystemTimer::new("ecs-maintain");
@@ -2104,5 +2152,95 @@ impl World {
                 .build(),
             entity_ids,
         )
+    }
+}
+
+#[cfg(test)]
+mod idle_gate_tests {
+    use super::*;
+    use crate::ClientFilter;
+
+    fn idle_world() -> World {
+        World::new("idle-gate-test", &WorldConfig::new().saving(false).build())
+    }
+
+    #[test]
+    fn fresh_world_with_no_work_is_idle() {
+        let world = idle_world();
+        assert!(
+            world.is_idle(),
+            "a fresh world with no clients or queued work should be idle"
+        );
+    }
+
+    #[test]
+    fn queued_pipeline_chunk_breaks_idle() {
+        let mut world = idle_world();
+        assert!(world.is_idle());
+        world.pipeline_mut().add_chunk(&Vec2(0, 0), false);
+        assert!(
+            !world.is_idle(),
+            "a queued pipeline chunk must keep the world busy"
+        );
+    }
+
+    #[test]
+    fn queued_mesher_chunk_breaks_idle() {
+        let mut world = idle_world();
+        world.mesher_mut().add_chunk(&Vec2(1, 2), false);
+        assert!(
+            !world.is_idle(),
+            "a queued mesher chunk must keep the world busy"
+        );
+    }
+
+    #[test]
+    fn staged_voxel_update_breaks_idle() {
+        let mut world = idle_world();
+        world.chunks_mut().update_voxel(&Vec3(3, 4, 5), 1);
+        assert!(
+            !world.is_idle(),
+            "a pending voxel update must keep the world busy"
+        );
+    }
+
+    #[test]
+    fn active_voxel_breaks_idle() {
+        let mut world = idle_world();
+        world.chunks_mut().mark_voxel_active(&Vec3(0, 1, 0), 10);
+        assert!(
+            !world.is_idle(),
+            "a scheduled active voxel must keep the world busy"
+        );
+    }
+
+    #[test]
+    fn pending_event_breaks_idle() {
+        let mut world = idle_world();
+        world.events_mut().dispatch(Event::new("test").build());
+        assert!(
+            !world.is_idle(),
+            "a queued event must keep the world busy"
+        );
+    }
+
+    #[test]
+    fn queued_broadcast_breaks_idle() {
+        let mut world = idle_world();
+        world.broadcast(Message::new(&MessageType::Chat).build(), ClientFilter::All);
+        assert!(
+            !world.is_idle(),
+            "a queued broadcast must keep the world busy"
+        );
+    }
+
+    #[test]
+    fn spawned_entity_breaks_idle() {
+        let mut world = idle_world();
+        world.create_entity("mob-1", "test").build();
+        assert!(
+            !world.is_idle(),
+            "a live entity must keep the world busy"
+        );
     }
 }

--- a/server/world/voxels/chunks.rs
+++ b/server/world/voxels/chunks.rs
@@ -454,6 +454,14 @@ impl Chunks {
         }
     }
 
+    pub fn is_idle(&self) -> bool {
+        self.updates.is_empty()
+            && self.updates_staging.is_empty()
+            && self.to_send.is_empty()
+            && self.to_save.is_empty()
+            && self.active_voxel_heap.is_empty()
+    }
+
     pub fn mark_voxel_active(&mut self, voxel: &Vec3<i32>, active_at: u64) {
         if self.active_voxel_set.contains_key(voxel) {
             return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

With no players connected, the Voxelize server pegged several cores at idle (~400% / ~4 cores on a many-core box).

### Root cause (verified)

The actix `Server` actor ticks **every** world at 62.5 Hz (`run_interval` in `server/server/mod.rs`), and every `World::tick` (`server/world/mod.rs`) ran the **full parallel** specs/shred ECS dispatch unconditionally. The dispatcher is built without `with_pool(...)`, so `shred` creates a **private, all-cores rayon pool per world**. Each dispatch calls `pool.install(...)`, so the pool was woken `num_worlds × 62.5` times/sec. Each wake spins up `num_cpus` workers that spin-search for work before going back to sleep. Idle cost therefore scaled with `num_cpus × num_worlds`.

## Fix — idle gate (primary)

Added `World::is_idle()` and skip the heavy parallel dispatch when a world has genuinely no work, so the shared rayon workers can actually sleep. A world is idle only when **all** of these hold:

- no clients connected, and no transports connected
- chunk pipeline empty (queue + in-flight set + pending regenerate)
- mesher empty (queue + in-flight set + pending remesh)
- voxel update queue empty (`updates` + `updates_staging`)
- active-voxel heap empty
- `to_send` and `to_save` queues empty
- event queue empty
- broadcast `MessageQueues` empty and `EncodedMessageQueue` empty (pending + processed + in-flight async encodes)
- no live ECS entities (player bodies, mobs, items, block entities — anything needing per-tick physics/AI/metadata)
- not preloading

### Why loaded behavior is unchanged (no perf regression)

- The busy path is byte-for-byte identical: when **any** of the above is non-empty, `is_idle()` returns `false` and the full all-cores parallel dispatch runs exactly as before. We do **not** force sequential dispatch and do **not** shrink the rayon pool.
- `ecs.maintain()` still runs on **every** tick (it is single-threaded and does not wake the pool), so entity creation/deletion driven by actor handlers settles immediately.
- The wake path has zero added latency: connections and client messages are processed by the actor **outside** the dispatch and mutate this state directly, so the moment a client joins / a chunk is requested / a voxel changes, the very next tick (≤16 ms, the normal cadence) sees non-empty state and resumes full dispatch. Skipping an idle tick cannot drop or delay queued work, because idle requires every queue and in-flight tracker to be empty.
- `UpdateStatsSystem` (tick counter / time-of-day) is skipped while idle: nothing observes it with no players, active-voxel scheduling requires the active-voxel heap to be non-empty (which forces non-idle), and `stats.delta` is already clamped, so resume after a long idle is safe.

## Secondary cleanups

- **Remove dead per-world pipeline rayon pool**: `Pipeline::process` schedules on the global pool via `rayon::spawn`, so the `ThreadPool` built in `Pipeline::new` was unused dead weight (extra all-cores worker threads + memory per world). Removed.
- **Stop re-ticking dead worlds**: when a world actor stops/panics, `run_interval` kept sending `Tick`, failing with `MailboxError` and logging a warn ~60–100×/sec/world (quietly eating a core). Such worlds are now tracked in `dead_worlds`, skipped on future ticks, and the failure is logged once.

## Verification

A/B on the demo server (debug build, 8 cores, no players):

| | idle CPU | threads | `World tick failed` warns |
|---|---|---|---|
| before (HEAD) | **28.0%** of one core | 62 | flooding ~60/sec (`test` world) |
| after (fix) | **5.0%** of one core | 57 | **0** |

End-to-end runtime lifecycle (terrain world), captured live:
- busy (`idle=false`) during preload → all worlds `idle=true` after preload (dispatch skipped)
- real client join → terrain `idle=false` **immediately** on the join tick (26 KB of init/chunk data sent)
- client leave → terrain settles back to `idle=true`

Added 8 unit tests (`idle_gate_tests`) proving a fresh world is idle and that each individual work source (pipeline chunk, mesher chunk, voxel update, active voxel, event, broadcast, live entity) flips it busy.

- ✅ `cargo build --lib` (needs `protoc` / `protobuf-compiler`)
- ✅ `cargo build --example demo`
- ✅ `cargo test --lib idle_gate_tests` (8 passed)
- ✅ A/B idle-CPU measurement + live join/leave wake trace

Note: the bundled `test` world has a pre-existing dispatcher bug (it never preloads); with the idle gate it stays idle and never builds its broken dispatcher, and if it ever did panic the `dead_worlds` change keeps it from spamming. Lighting/chunk algorithms are untouched.

[idle_cpu_evidence.txt](https://cursor.com/artifacts/c/art-caa1205e-70a5-4d8f-87f0-d82f52c6ad18)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2315b075-d1ef-4b89-947f-f5c14e893fda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2315b075-d1ef-4b89-947f-f5c14e893fda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

