### PR TITLE
Gate client voxel UPDATEs behind WorldConfig

### DIFF
--- a/server/world/config.rs
+++ b/server/world/config.rs
@@ -101,6 +101,11 @@ pub struct WorldConfig {
     /// Whether chunk geometry should only be built by clients. Default is true.
     pub client_only_meshing: bool,
 
+    /// When false (default), inbound client `UPDATE` / bulk voxel writes are
+    /// ignored in `World::on_update`. Games that need client-authored terrain
+    /// (e.g. creative sandboxes) can opt in; server-authoritative games keep
+    /// this off and write voxels only from method/event handlers.
+    pub allow_client_voxel_writes: bool,
 
     pub entity_visible_radius: f32,
 }
@@ -152,6 +157,7 @@ const DEFAULT_SAVE_DIR: &str = "";
 const DEFAULT_SAVE_INTERVAL: usize = 300;
 const DEFAULT_COMMAND_SYMBOL: &str = "/";
 const DEFAULT_CLIENT_ONLY_MESHING: bool = true;
+const DEFAULT_ALLOW_CLIENT_VOXEL_WRITES: bool = false;
 
 /// Builder for a world configuration.
 pub struct WorldConfigBuilder {
@@ -187,6 +193,7 @@ pub struct WorldConfigBuilder {
     command_symbol: String,
     save_entities: bool,
     client_only_meshing: bool,
+    allow_client_voxel_writes: bool,
     entity_visible_radius: f32,
 }
 
@@ -226,6 +233,7 @@ impl WorldConfigBuilder {
             command_symbol: DEFAULT_COMMAND_SYMBOL.to_owned(),
             save_entities: true,
             client_only_meshing: DEFAULT_CLIENT_ONLY_MESHING,
+            allow_client_voxel_writes: DEFAULT_ALLOW_CLIENT_VOXEL_WRITES,
             entity_visible_radius: 0.0,
         }
     }
@@ -399,6 +407,12 @@ impl WorldConfigBuilder {
         self
     }
 
+    /// When false (default), inbound client voxel UPDATEs are ignored.
+    pub fn allow_client_voxel_writes(mut self, allow_client_voxel_writes: bool) -> Self {
+        self.allow_client_voxel_writes = allow_client_voxel_writes;
+        self
+    }
+
     pub fn entity_visible_radius(mut self, entity_visible_radius: f32) -> Self {
         self.entity_visible_radius = entity_visible_radius;
         self
@@ -452,6 +466,7 @@ impl WorldConfigBuilder {
             command_symbol: self.command_symbol,
             save_entities: self.save_entities,
             client_only_meshing: self.client_only_meshing,
+            allow_client_voxel_writes: self.allow_client_voxel_writes,
             entity_visible_radius: if self.entity_visible_radius > 0.0 {
                 self.entity_visible_radius
             } else {

--- a/server/world/mod.rs
+++ b/server/world/mod.rs
@@ -26,7 +26,7 @@ use actix::{
 };
 use actix::{Addr, SyncArbiter};
 use hashbrown::HashMap;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use metadata::WorldMetadata;
 use nanoid::nanoid;
 use profiler::Profiler;
@@ -39,6 +39,7 @@ use specs::{
 };
 use std::f64::consts::E;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, RwLock};
 use std::{env, sync::Arc};
 use std::{
@@ -85,6 +86,9 @@ const CLIENT_BODY_DEPTH: f32 = 0.8;
 const CLIENT_CROUCH_BODY_HEIGHT_RATIO: f32 = 0.83;
 const CLIENT_SWIM_BODY_HEIGHT: f32 = 0.4;
 const CLIENT_AABB_HEIGHT_EPSILON: f32 = 0.01;
+
+/// Count of inbound client voxel UPDATEs dropped while `allow_client_voxel_writes` is false.
+static CLIENT_VOXEL_UPDATE_REJECTED: AtomicU64 = AtomicU64::new(0);
 
 fn apply_client_ghost_state(body: &mut RigidBodyComp, is_ghost: bool) {
     let position = body.0.get_position();
@@ -1811,6 +1815,7 @@ impl World {
     /// Handler for `Update` type messages.
     fn on_update(&mut self, _: &str, data: Message) {
         let chunk_size = self.config().chunk_size;
+        let allow_client_writes = self.config().allow_client_voxel_writes;
         let mut chunks = self.chunks_mut();
 
         if let Some(bulk) = data.bulk_update {
@@ -1826,6 +1831,14 @@ impl World {
                     continue;
                 }
 
+                if !allow_client_writes {
+                    let n = CLIENT_VOXEL_UPDATE_REJECTED.fetch_add(1, Ordering::Relaxed) + 1;
+                    debug!(
+                        "rejected client bulk voxel write #{n} at ({vx},{vy},{vz}) -> {voxel} (allow_client_voxel_writes=false)"
+                    );
+                    continue;
+                }
+
                 chunks.update_voxel(&Vec3(vx, vy, vz), voxel);
             }
         } else {
@@ -1834,6 +1847,15 @@ impl World {
                     ChunkUtils::map_voxel_to_chunk(update.vx, update.vy, update.vz, chunk_size);
 
                 if !chunks.is_within_world(&coords) {
+                    return;
+                }
+
+                if !allow_client_writes {
+                    let n = CLIENT_VOXEL_UPDATE_REJECTED.fetch_add(1, Ordering::Relaxed) + 1;
+                    debug!(
+                        "rejected client voxel write #{n} at ({},{},{}) -> {} (allow_client_voxel_writes=false)",
+                        update.vx, update.vy, update.vz, update.voxel
+                    );
                     return;
                 }
 


### PR DESCRIPTION
# Gate client voxel UPDATEs behind WorldConfig

## Summary

Adds `WorldConfig.allow_client_voxel_writes` (default **`false`**).

When disabled, `World::on_update` still validates chunk bounds for inbound
client `UPDATE` messages but **skips** `chunks.update_voxel`, bumps a reject
counter, and logs at debug. Games that want creative client digging can opt in
with `.allow_client_voxel_writes(true)`.

## Why upstream

Multiplayer / survival games commonly need server-authoritative voxels.
Defaulting client UPDATEs off prevents accidental world corruption and
cheat digs without requiring every game to reimplement the gate.

## Test plan

- [ ] Default config: client UPDATE voxels do not change server chunks
- [ ] Opt-in true: client UPDATEs apply as today
- [ ] Out-of-bounds UPDATE still rejected / no panic

## Spireash

Spireash sets `.allow_client_voxel_writes(false)` and mutates voxels only via
server methods (`mine-block` / `place-block`).

## Patch

`docs/voxelize-upstream/patches/0002-feat-server-gate-client-voxel-UPDATEs-behind-WorldCo.patch`

Branch tip: `upstream-prep/stack-voxel-writes`
