### PR TITLE
Fix case-insensitive method dispatch (avoid panic / lock poison)

### DIFF
--- a/server/world/mod.rs
+++ b/server/world/mod.rs
@@ -1845,18 +1845,14 @@ impl World {
     /// Handler for `Method` type messages.
     fn on_method(&mut self, client_id: &str, data: Message) {
         if let Some(method) = data.method {
-            if !self
-                .method_handles
-                .contains_key(&method.name.to_lowercase())
-            {
+            let key = method.name.to_lowercase();
+            let Some(handle) = self.method_handles.get(&key).map(|h| h.to_owned()) else {
                 warn!(
                     "`Method` type messages received of name {}, but no method handler set.",
                     method.name
                 );
                 return;
-            }
-
-            let handle = self.method_handles.get(&method.name).unwrap().to_owned();
+            };
 
             handle(self, client_id, &method.payload);
         }


### PR DESCRIPTION
# Fix case-insensitive method dispatch (avoid panic / lock poison)

## Summary

`set_method_handle` already stores keys lowercased, but `on_method` looked up
handlers with the **raw** client-provided name after a lowercase
`contains_key` check. A mixed-case method name (e.g. `Mine-Block` vs
`mine-block`) passed the contains check then **`unwrap()` panicked** on the
mismatched get — poisoning the world lock and DoS'ing the process.

Fix: look up once with `method.name.to_lowercase()` and use that handle.

## Why upstream

Any game with remappable / third-party clients can send varied casing. A
panic on a single bad METHOD packet should never take down the world.

## Test plan

- [ ] Registered `mine-block`; client sends `Mine-Block` / `MINE-BLOCK` → handler runs
- [ ] Unknown method → warn + return, no panic
- [ ] World continues ticking after mixed-case traffic

## Patch

`docs/voxelize-upstream/patches/0003-fix-case-insensitive-method-dispatch-ClientRequest-c.patch`

Branch tip: `upstream-prep/stack-method-case`

## Note

Commit message mentions `ClientRequest catch_unwind`; that hardening already
exists elsewhere in `server/world/mod.rs`. This PR is specifically the
lookup-key fix.
