### PR TITLE
Add Physics::displace_body (voxel-safe entity displace)

### DIFF
--- a/server/world/physics/mod.rs
+++ b/server/world/physics/mod.rs
@@ -310,6 +310,37 @@ impl Physics {
         }
     }
 
+    /// Instantaneously displace a rigid body by `delta`, stopping at the first
+    /// voxel AABB collision (full body sweep via [`sweep`]). Updates
+    /// `body.resting` and zeroes velocity on collided axes.
+    ///
+    /// Use this for AI lunges / dashes / forced moves that must not teleport
+    /// through walls. Prefer it over `RigidBody::set_position` for any gameplay
+    /// translation that should respect voxel collision. Normal locomotion still
+    /// goes through [`Physics::iterate_body`] (forces / impulses / gravity).
+    ///
+    /// Returns the actual world-space displacement applied (may be shorter than
+    /// `delta` when a wall was hit).
+    pub fn displace_body(
+        body: &mut RigidBody,
+        delta: &Vec3<f32>,
+        space: &dyn VoxelAccess,
+        registry: &Registry,
+    ) -> Vec3<f32> {
+        let before = body.get_position();
+        let mut resting = Vec3::default();
+        Physics::process_collisions(space, registry, &mut body.aabb, delta, &mut resting);
+        body.resting = resting;
+        for i in 0..3 {
+            if body.resting[i] != 0 {
+                body.velocity[i] = 0.0;
+            }
+        }
+        body.mark_active();
+        let after = body.get_position();
+        Vec3(after.0 - before.0, after.1 - before.1, after.2 - before.2)
+    }
+
     pub fn is_body_asleep(
         space: &dyn VoxelAccess,
         registry: &Registry,
@@ -665,5 +696,75 @@ impl Physics {
         body.resting[0] = tmp_resting[0];
         body.resting[2] = tmp_resting[2];
         body.stepped = true;
+    }
+}
+
+#[cfg(test)]
+mod displace_body_tests {
+    use super::*;
+    use crate::{Block, Chunk, ChunkOptions, Registry};
+
+    fn solid_floor_chunk(floor_y: i32) -> (Chunk, Registry) {
+        let mut registry = Registry::new();
+        registry.register_block(&Block::new("Stone").id(5).build());
+        let opts = ChunkOptions {
+            size: 16,
+            max_height: 64,
+            sub_chunks: 4,
+        };
+        let mut chunk = Chunk::new("displace", 0, 0, &opts);
+        for x in 0..16 {
+            for z in 0..16 {
+                chunk.set_voxel(x, floor_y, z, 5);
+            }
+        }
+        // Vertical wall at x=12, y=floor+1..floor+3
+        for y in (floor_y + 1)..=(floor_y + 3) {
+            for z in 0..16 {
+                chunk.set_voxel(12, y, z, 5);
+            }
+        }
+        (chunk, registry)
+    }
+
+    #[test]
+    fn displace_body_stops_before_voxel_wall() {
+        let floor_y = 10;
+        let (chunk, registry) = solid_floor_chunk(floor_y);
+        let aabb = AABB::new().scale_x(0.7).scale_y(1.0).scale_z(0.7).build();
+        let mut body = RigidBody::new(&aabb).build();
+        // Hover clear of the floor slab so only the vertical wall can stop us.
+        // Wall occupies voxel x=12 → solid AABB [12,13); half-width 0.35 →
+        // center must stay < 12.0 - 0.35 = 11.65.
+        body.set_position(8.5, floor_y as f32 + 2.5, 8.5);
+
+        let moved = Physics::displace_body(&mut body, &Vec3(6.0, 0.0, 0.0), &chunk, &registry);
+        let pos = body.get_position();
+        assert!(moved.0 > 1.0, "should move toward the wall, moved={moved:?}");
+        assert!(
+            moved.0 < 6.0 - 0.01,
+            "must not complete full 6u teleport through wall, moved={moved:?}"
+        );
+        assert!(
+            pos.0 < 12.0 - 0.3,
+            "body center must stay west of wall face, pos={pos:?}"
+        );
+        assert_eq!(body.resting[0], 1, "should rest against +X wall");
+    }
+
+    #[test]
+    fn displace_body_open_air_applies_full_delta() {
+        let floor_y = 10;
+        let (chunk, registry) = solid_floor_chunk(floor_y);
+        let aabb = AABB::new().scale_x(0.5).scale_y(0.8).scale_z(0.5).build();
+        let mut body = RigidBody::new(&aabb).build();
+        body.set_position(4.0, floor_y as f32 + 2.5, 4.0);
+
+        let moved = Physics::displace_body(&mut body, &Vec3(1.5, 0.0, 0.0), &chunk, &registry);
+        assert!(
+            (moved.0 - 1.5).abs() < 0.02,
+            "open path should apply full delta, moved={moved:?}"
+        );
+        assert_eq!(body.resting[0], 0);
     }
 }


### PR DESCRIPTION
# Upstream PR: `Physics::displace_body` (voxel-safe entity displace)

## Summary

Expose a public helper that displaces a `RigidBody` by a world-space delta using
the engine's existing full-body voxel AABB sweep, stopping at the first solid
collision. Games use this for AI lunges / dashes / forced moves instead of
teleporting with `set_position` (which ignores voxel collision).

## Motivation

Voxelize already owns continuous locomotion via `Physics::iterate_body`
(forces, impulses, gravity, auto-step). Games still hand-roll
"move until wall" for combat dashes by sampling voxel centers and calling
`set_position`, which:

1. Misses partial block AABBs that `sweep` already handles.
2. Can embed bodies in solids and then tunnel under gravity.
3. Duplicates engine collision in every game.

A one-shot displace that reuses `process_collisions` / `sweep` is the generic
fix.

## API

```rust
impl Physics {
    /// Instantaneously displace `body` by `delta`, stopping at the first voxel
    /// AABB hit. Updates `body.resting`, zeroes velocity on collided axes,
    /// marks the body active. Returns the actual displacement applied.
    pub fn displace_body(
        body: &mut RigidBody,
        delta: &Vec3<f32>,
        space: &dyn VoxelAccess,
        registry: &Registry,
    ) -> Vec3<f32>;
}
```

Normal locomotion remains `iterate_body`. Entity–entity overlap remains Rapier
`collision_repulsion`. This API is only the missing "forced move with voxel
collision" primitive.

## Out of scope

- Attack line-of-sight / combat fairness rays (game policy).
- Melee standoff distances / strike-reach tables (game content).
- A loot / item-drop system (attach `RigidBodyComp` and use `iterate_body`).
- Changing default `auto_step` for NPCs.

## Test plan

- Unit: `displace_body_stops_before_voxel_wall` — body approaching a solid
  wall stops with `resting[0] != 0` and center west of the wall face.
- Unit: `displace_body_open_air_applies_full_delta` — clear path applies the
  full delta.

## Spireash consumer (separate follow-on)

Replace `lunge_until_blocked` teleports in
`apps/server/src/game/systems.rs` with `Physics::displace_body`. Keep kind
tuning in apps/. Prove with `bin/run-mob-ai-matrix-verify` +
`tools/mob-attack-fairness-verify.mjs`.

## Suggested fork branch

`spireash/displace-body`
