### PR TITLE
feat(server): unified state replication layer — last-value-wins state, reliable events, idempotent join lifecycle

### DIFF
--- a/server/lib.rs
+++ b/server/lib.rs
@@ -142,8 +142,13 @@ async fn handle_ws_connection(
     mut stream: impl StreamExt<Item = Result<AggregatedMessage, actix_ws::ProtocolError>> + Unpin,
     server: Addr<Server>,
 ) {
-    let (raw_tx, mut rx) = mpsc::unbounded_channel::<Vec<u8>>();
-    let tx = WsSender::new(raw_tx);
+    // Two outbound lanes per connection (see `WsSender`): control traffic
+    // (session lifecycle, chat, entity/peer state) is written before bulk
+    // world data (chunks, voxel updates), so a client streaming megabytes of
+    // chunks still receives JOIN/LEAVE and live state promptly.
+    let (control_tx, mut control_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let (bulk_tx, mut bulk_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let tx = WsSender::new(control_tx, bulk_tx);
 
     let (session_id, connection_token) = match server
         .send(Connect {
@@ -171,11 +176,18 @@ async fn handle_ws_connection(
     let mut last_seen = std::time::Instant::now();
 
     loop {
+        // `biased` gives the control lane strict priority over the bulk lane:
+        // whenever both have pending messages, session lifecycle / state
+        // snapshots are written first and can never be starved behind queued
+        // chunk data. Depths are decremented only after the socket write
+        // completes: the state-flush gate uses control-lane depth as a
+        // liveness signal, and a stalled write (peer stopped reading) must
+        // keep counting as backlog.
         tokio::select! {
-            Some(msg) = rx.recv() => {
-                tx.mark_received();
+            biased;
+            Some(msg) = control_rx.recv() => {
                 match tokio::time::timeout(WS_WRITE_TIMEOUT, session.binary(msg)).await {
-                    Ok(Ok(())) => {}
+                    Ok(Ok(())) => tx.mark_control_written(),
                     Ok(Err(_)) => break,
                     Err(_) => {
                         warn!("[WS] Write stalled for {}; dropping connection", session_id);
@@ -256,6 +268,16 @@ async fn handle_ws_connection(
                         break;
                     }
                     None => break,
+                }
+            }
+            Some(msg) = bulk_rx.recv() => {
+                match tokio::time::timeout(WS_WRITE_TIMEOUT, session.binary(msg)).await {
+                    Ok(Ok(())) => tx.mark_bulk_written(),
+                    Ok(Err(_)) => break,
+                    Err(_) => {
+                        warn!("[WS] Bulk write stalled for {}; dropping connection", session_id);
+                        break;
+                    }
                 }
             }
         }

--- a/server/server/mod.rs
+++ b/server/server/mod.rs
@@ -31,39 +31,81 @@ use crate::{
 
 pub use models::*;
 
+/// A per-connection sender with two priority lanes.
+///
+/// - The CONTROL lane carries session control-plane and small ordered traffic
+///   (INIT, JOIN/LEAVE, errors, chat, methods, events, entity lifecycle, and
+///   coalesced state snapshots). It is drained *first* by the connection's
+///   write loop, so lifecycle and live state can never be starved behind
+///   megabytes of queued chunk data.
+/// - The BULK lane carries world-data-plane traffic (chunk loads/unloads and
+///   voxel updates, which must stay ordered relative to each other).
+///
+/// Depths count messages pushed but not yet *written to the socket* (one
+/// relaxed atomic per message). The state replication layer gates its
+/// per-client flush on the control-lane depth: a truly dead socket stalls
+/// writes, the control depth climbs, and state coalesces in its slots instead
+/// of piling up as stale frames. See `world::replication`.
 #[derive(Clone)]
 pub struct WsSender {
-    sender: mpsc::UnboundedSender<Vec<u8>>,
-    /// Messages pushed but not yet written to the socket. Always tracked (one
-    /// relaxed atomic per message): the state replication layer gates its
-    /// per-client flush on this depth so a slow client coalesces instead of
-    /// accumulating stale positional frames. See `world::replication`.
-    depth: Arc<AtomicUsize>,
+    control: mpsc::UnboundedSender<Vec<u8>>,
+    bulk: mpsc::UnboundedSender<Vec<u8>>,
+    control_depth: Arc<AtomicUsize>,
+    bulk_depth: Arc<AtomicUsize>,
 }
 
 impl WsSender {
-    pub fn new(sender: mpsc::UnboundedSender<Vec<u8>>) -> Self {
+    pub fn new(
+        control: mpsc::UnboundedSender<Vec<u8>>,
+        bulk: mpsc::UnboundedSender<Vec<u8>>,
+    ) -> Self {
         Self {
-            sender,
-            depth: Arc::new(AtomicUsize::new(0)),
+            control,
+            bulk,
+            control_depth: Arc::new(AtomicUsize::new(0)),
+            bulk_depth: Arc::new(AtomicUsize::new(0)),
         }
     }
 
+    /// Send on the control lane (default). Reliable-ordered within the lane.
     pub fn send(&self, data: Vec<u8>) -> Result<(), mpsc::error::SendError<Vec<u8>>> {
-        self.depth.fetch_add(1, Ordering::Relaxed);
-        if let Err(error) = self.sender.send(data) {
-            self.depth.fetch_sub(1, Ordering::Relaxed);
+        self.control_depth.fetch_add(1, Ordering::Relaxed);
+        if let Err(error) = self.control.send(data) {
+            self.control_depth.fetch_sub(1, Ordering::Relaxed);
             return Err(error);
         }
         Ok(())
     }
 
-    pub fn mark_received(&self) {
-        self.depth.fetch_sub(1, Ordering::Relaxed);
+    /// Send on the bulk lane (chunk data, voxel updates). Reliable-ordered
+    /// within the lane, but drained only when the control lane is empty.
+    pub fn send_bulk(&self, data: Vec<u8>) -> Result<(), mpsc::error::SendError<Vec<u8>>> {
+        self.bulk_depth.fetch_add(1, Ordering::Relaxed);
+        if let Err(error) = self.bulk.send(data) {
+            self.bulk_depth.fetch_sub(1, Ordering::Relaxed);
+            return Err(error);
+        }
+        Ok(())
     }
 
+    pub fn mark_control_written(&self) {
+        self.control_depth.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    pub fn mark_bulk_written(&self) {
+        self.bulk_depth.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Control-lane backlog only: the signal the state-flush gate uses. Bulk
+    /// chunk streaming must not block live state — that starvation is exactly
+    /// what made peer visibility asymmetric for clients loading chunks.
+    pub fn control_len(&self) -> usize {
+        self.control_depth.load(Ordering::Relaxed)
+    }
+
+    /// Total unwritten messages across both lanes (observability).
     pub fn len(&self) -> usize {
-        self.depth.load(Ordering::Relaxed)
+        self.control_depth.load(Ordering::Relaxed) + self.bulk_depth.load(Ordering::Relaxed)
     }
 }
 
@@ -1352,9 +1394,14 @@ mod lifecycle_tests {
             .build()
     }
 
+    /// Fake connection: returns the sender and its control-lane receiver.
+    /// Session lifecycle traffic (INIT, ERROR, JOIN/LEAVE) rides the control
+    /// lane; these tests never exercise the bulk lane, so its receiver is
+    /// dropped and bulk sends would error harmlessly.
     fn fake_socket() -> (WsSender, mpsc::UnboundedReceiver<Vec<u8>>) {
-        let (tx, rx) = mpsc::unbounded_channel();
-        (WsSender::new(tx), rx)
+        let (control_tx, control_rx) = mpsc::unbounded_channel();
+        let (bulk_tx, _) = mpsc::unbounded_channel();
+        (WsSender::new(control_tx, bulk_tx), control_rx)
     }
 
     /// Await the world's mailbox draining (SyncArbiter processes messages
@@ -1371,14 +1418,37 @@ mod lifecycle_tests {
             .client_count
     }
 
-    fn drain_message_types(rx: &mut mpsc::UnboundedReceiver<Vec<u8>>) -> Vec<i32> {
-        let mut types = vec![];
+    /// Drain everything on a fake socket's control lane, marking each message
+    /// written so the sender's depth (the state-flush gate signal) reflects a
+    /// live socket. Undecodable payloads (test filler) are skipped.
+    fn drain_messages(sender: &WsSender, rx: &mut mpsc::UnboundedReceiver<Vec<u8>>) -> Vec<Message> {
+        let mut messages = vec![];
         while let Ok(bytes) = rx.try_recv() {
+            sender.mark_control_written();
             if let Ok(message) = decode_message(&bytes) {
-                types.push(message.r#type);
+                messages.push(message);
             }
         }
-        types
+        messages
+    }
+
+    fn drain_message_types(
+        sender: &WsSender,
+        rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    ) -> Vec<i32> {
+        drain_messages(sender, rx)
+            .into_iter()
+            .map(|message| message.r#type)
+            .collect()
+    }
+
+    /// All peer ids mentioned across PEER messages in a drained batch.
+    fn peer_ids_in(messages: &[Message]) -> Vec<String> {
+        messages
+            .iter()
+            .filter(|m| m.r#type == MessageType::Peer as i32)
+            .flat_map(|m| m.peers.iter().map(|p| p.id.clone()))
+            .collect()
     }
 
     fn build_server_with_world() -> Server {
@@ -1399,7 +1469,7 @@ mod lifecycle_tests {
         actix::System::new().block_on(async {
             let mut server = build_server_with_world();
             let (sender, mut rx) = fake_socket();
-            let (id, token) = server.register_session(Some("bot".into()), false, sender);
+            let (id, token) = server.register_session(Some("bot".into()), false, sender.clone());
 
             // First JOIN, then a retry as if the INIT ack was lost in flight.
             assert_eq!(on_request(&mut server, &id, &token, join_message(WORLD)), None);
@@ -1411,7 +1481,7 @@ mod lifecycle_tests {
 
             assert_eq!(world_client_count(&server).await, 1, "no duplicate entity");
 
-            let types = drain_message_types(&mut rx);
+            let types = drain_message_types(&sender, &mut rx);
             let inits = types
                 .iter()
                 .filter(|t| **t == MessageType::Init as i32)
@@ -1426,14 +1496,14 @@ mod lifecycle_tests {
             let mut server = build_server_with_world();
 
             let (old_sender, _old_rx) = fake_socket();
-            let (id, old_token) = server.register_session(Some("bot".into()), false, old_sender);
+            let (id, old_token) = server.register_session(Some("bot".into()), false, old_sender.clone());
             assert_eq!(on_request(&mut server, &id, &old_token, join_message(WORLD)), None);
             assert_eq!(world_client_count(&server).await, 1);
 
             // Abrupt closure: no Leave, no Disconnect — the process died. A
             // fresh connection with the same id must replace the membership.
             let (new_sender, mut new_rx) = fake_socket();
-            let (_, new_token) = server.register_session(Some("bot".into()), false, new_sender);
+            let (_, new_token) = server.register_session(Some("bot".into()), false, new_sender.clone());
             assert_eq!(
                 on_request(&mut server, &id, &new_token, join_message(WORLD)),
                 None,
@@ -1441,7 +1511,7 @@ mod lifecycle_tests {
             );
 
             assert_eq!(world_client_count(&server).await, 1, "exactly one live entity");
-            let types = drain_message_types(&mut new_rx);
+            let types = drain_message_types(&new_sender, &mut new_rx);
             assert!(
                 types.contains(&(MessageType::Init as i32)),
                 "new session receives the INIT ack"
@@ -1461,15 +1531,15 @@ mod lifecycle_tests {
             let mut server = build_server_with_world();
 
             let (old_sender, mut old_rx) = fake_socket();
-            let (id, old_token) = server.register_session(Some("bot".into()), false, old_sender);
+            let (id, old_token) = server.register_session(Some("bot".into()), false, old_sender.clone());
             assert_eq!(on_request(&mut server, &id, &old_token, join_message(WORLD)), None);
 
             // New socket connects while the old one is still open.
             let (new_sender, _new_rx) = fake_socket();
-            let (_, new_token) = server.register_session(Some("bot".into()), false, new_sender);
+            let (_, new_token) = server.register_session(Some("bot".into()), false, new_sender.clone());
 
             // Old socket was kicked with a reliable ERROR message.
-            let old_types = drain_message_types(&mut old_rx);
+            let old_types = drain_message_types(&old_sender, &mut old_rx);
             assert!(old_types.contains(&(MessageType::Error as i32)));
 
             // The old socket's JOIN retry races the new socket's JOIN: it
@@ -1488,7 +1558,7 @@ mod lifecycle_tests {
             let mut server = build_server_with_world();
 
             let (sender, _rx) = fake_socket();
-            let (id, token) = server.register_session(Some("bot".into()), false, sender);
+            let (id, token) = server.register_session(Some("bot".into()), false, sender.clone());
             assert_eq!(on_request(&mut server, &id, &token, join_message(WORLD)), None);
             assert_eq!(world_client_count(&server).await, 1);
 
@@ -1499,10 +1569,10 @@ mod lifecycle_tests {
 
             // A later reconnect with the same id starts a clean session.
             let (sender, mut rx) = fake_socket();
-            let (_, token) = server.register_session(Some("bot".into()), false, sender);
+            let (_, token) = server.register_session(Some("bot".into()), false, sender.clone());
             assert_eq!(on_request(&mut server, &id, &token, join_message(WORLD)), None);
             assert_eq!(world_client_count(&server).await, 1);
-            assert!(drain_message_types(&mut rx).contains(&(MessageType::Init as i32)));
+            assert!(drain_message_types(&sender, &mut rx).contains(&(MessageType::Init as i32)));
         });
     }
 
@@ -1512,7 +1582,7 @@ mod lifecycle_tests {
             let mut server = build_server_with_world();
 
             let (sender, _rx) = fake_socket();
-            let (id, token) = server.register_session(Some("bot".into()), false, sender);
+            let (id, token) = server.register_session(Some("bot".into()), false, sender.clone());
 
             let error = on_request(&mut server, &id, &token, join_message("nowhere"));
             assert!(error.is_some());
@@ -1524,12 +1594,138 @@ mod lifecycle_tests {
     }
 
     #[test]
+    fn peer_visibility_is_bidirectional_and_lifecycle_survives_backlog() {
+        actix::System::new().block_on(async {
+            let mut server = build_server_with_world();
+            let world_addr = server.worlds.get(WORLD).unwrap().clone();
+            let tick = |n: usize| {
+                let world_addr = world_addr.clone();
+                async move {
+                    for _ in 0..n {
+                        world_addr.send(crate::Tick).await.unwrap();
+                    }
+                }
+            };
+
+            // A joins first and settles (its metadata dirty flag is long
+            // consumed by the time B joins).
+            let (sender_a, mut rx_a) = fake_socket();
+            let (id_a, token_a) =
+                server.register_session(Some("visA".into()), false, sender_a.clone());
+            assert_eq!(on_request(&mut server, &id_a, &token_a, join_message(WORLD)), None);
+            tick(4).await;
+            drain_messages(&sender_a, &mut rx_a);
+
+            // B joins later.
+            let (sender_b, mut rx_b) = fake_socket();
+            let (id_b, token_b) =
+                server.register_session(Some("visB".into()), false, sender_b.clone());
+            assert_eq!(on_request(&mut server, &id_b, &token_b, join_message(WORLD)), None);
+            tick(4).await;
+
+            // A must learn about B: reliable JOIN exactly once + peer state.
+            let a_messages = drain_messages(&sender_a, &mut rx_a);
+            let joins_for_b = a_messages
+                .iter()
+                .filter(|m| m.r#type == MessageType::Join as i32 && m.text == id_b)
+                .count();
+            assert_eq!(joins_for_b, 1, "existing client gets exactly one JOIN for newcomer");
+            let a_peer_ids = peer_ids_in(&a_messages);
+            assert!(
+                a_peer_ids.contains(&id_b),
+                "existing client receives newcomer's peer state"
+            );
+            assert!(!a_peer_ids.contains(&id_a), "no self peer echo");
+
+            // B must learn about A: INIT peers + full state re-sync.
+            let b_messages = drain_messages(&sender_b, &mut rx_b);
+            let init = b_messages
+                .iter()
+                .find(|m| m.r#type == MessageType::Init as i32)
+                .expect("newcomer receives INIT");
+            assert!(
+                init.peers.iter().any(|p| p.id == id_a),
+                "newcomer INIT lists existing peers"
+            );
+            assert!(
+                peer_ids_in(&b_messages).contains(&id_a),
+                "newcomer receives existing peers' state"
+            );
+
+            // B moves; A converges to B's latest position.
+            let move_b = Message::new(&MessageType::Peer)
+                .peers(&[crate::PeerProtocol {
+                    id: String::new(),
+                    username: "visB".into(),
+                    metadata: json!({ "position": [5.0, 0.0, 0.0] }).to_string(),
+                }])
+                .build();
+            assert_eq!(server.on_request(&id_b, move_b, None, 0, Some(&token_b)), None);
+            tick(4).await;
+            let a_messages = drain_messages(&sender_a, &mut rx_a);
+            let b_position = a_messages
+                .iter()
+                .filter(|m| m.r#type == MessageType::Peer as i32)
+                .flat_map(|m| m.peers.iter())
+                .filter(|p| p.id == id_b)
+                .filter_map(|p| {
+                    serde_json::from_str::<Value>(&p.metadata)
+                        .ok()?
+                        .get("position")?
+                        .get(0)?
+                        .as_f64()
+                })
+                .last();
+            assert_eq!(b_position, Some(5.0), "A receives B's latest position");
+
+            // Backlog A's socket (undrained control lane past the gate), then
+            // have B move and leave. Reliable lifecycle must not be starved:
+            // the LEAVE arrives even though state flushing is gated, and no
+            // stale state for B is delivered after it.
+            for _ in 0..(crate::STATE_FLUSH_MAX_SOCKET_BACKLOG * 2) {
+                let _ = sender_a.send(vec![0]);
+            }
+            let move_b = Message::new(&MessageType::Peer)
+                .peers(&[crate::PeerProtocol {
+                    id: String::new(),
+                    username: "visB".into(),
+                    metadata: json!({ "position": [8.0, 0.0, 0.0] }).to_string(),
+                }])
+                .build();
+            assert_eq!(server.on_request(&id_b, move_b, None, 0, Some(&token_b)), None);
+            tick(2).await;
+            let leave_b = Message::new(&MessageType::Leave).text(WORLD).build();
+            assert_eq!(server.on_request(&id_b, leave_b, None, 0, Some(&token_b)), None);
+            tick(4).await;
+
+            let a_messages = drain_messages(&sender_a, &mut rx_a);
+            let leave_index = a_messages
+                .iter()
+                .position(|m| m.r#type == MessageType::Leave as i32 && m.text == id_b);
+            assert!(
+                leave_index.is_some(),
+                "backlogged client still receives the reliable LEAVE"
+            );
+            let peers_after_leave = a_messages[leave_index.unwrap()..]
+                .iter()
+                .filter(|m| m.r#type == MessageType::Peer as i32)
+                .flat_map(|m| m.peers.iter())
+                .any(|p| p.id == id_b);
+            assert!(
+                !peers_after_leave,
+                "no stale peer state is delivered after the LEAVE"
+            );
+            assert_eq!(world_client_count(&server).await, 1, "B removed from world");
+        });
+    }
+
+    #[test]
     fn malformed_join_payload_is_a_typed_error_not_a_panic() {
         actix::System::new().block_on(async {
             let mut server = build_server_with_world();
 
             let (sender, _rx) = fake_socket();
-            let (id, token) = server.register_session(Some("bot".into()), false, sender);
+            let (id, token) = server.register_session(Some("bot".into()), false, sender.clone());
 
             let message = Message::new(&MessageType::Join).json("{not json").build();
             let error = on_request(&mut server, &id, &token, message);

--- a/server/world/components/metadata.rs
+++ b/server/world/components/metadata.rs
@@ -71,6 +71,13 @@ impl MetadataComp {
         serde_json::to_string(&self.map).unwrap()
     }
 
+    /// Force the next `to_cached_str` to report a change, so this metadata is
+    /// re-emitted to consumers even if its content did not change. Used to
+    /// deterministically re-sync peer state when world membership changes.
+    pub fn mark_dirty(&mut self) {
+        self.last_emitted_json = None;
+    }
+
     /// Is the metadata empty?
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()

--- a/server/world/mod.rs
+++ b/server/world/mod.rs
@@ -1073,6 +1073,22 @@ impl World {
             .get(ent)
             .map(|body| body.0.is_swimming);
 
+        // Deterministic peer re-sync on membership change: force every
+        // client's peer metadata dirty so the next peers-sending run stages a
+        // full snapshot of everyone to everyone. Bidirectional visibility
+        // must NOT depend on the one-tick metadata dirty flag happening to
+        // fire after this join — an idle existing player would otherwise
+        // never be re-announced to the newcomer, and (worse) the newcomer's
+        // single dirty tick is the only tick existing clients would ever hear
+        // about it on.
+        {
+            let flags = self.ecs.read_storage::<ClientFlag>();
+            let mut metadatas = self.ecs.write_storage::<MetadataComp>();
+            for (metadata, _) in (&mut metadatas, &flags).join() {
+                metadata.mark_dirty();
+            }
+        }
+
         let (init_message, init_entity_ids) = self.generate_init_message(
             id,
             saved_position,

--- a/server/world/systems/broadcast.rs
+++ b/server/world/systems/broadcast.rs
@@ -47,7 +47,13 @@ fn can_batch(msg_type: i32) -> bool {
 
 fn is_immediate(message: &Message) -> bool {
     match MessageType::try_from(message.r#type) {
-        Ok(MessageType::Chat) | Ok(MessageType::Method) => true,
+        // Session control-plane (JOIN/LEAVE peer lifecycle) and interactive
+        // messages encode synchronously and go out the same tick — they must
+        // never lose a tick to the async encode round-trip.
+        Ok(MessageType::Chat)
+        | Ok(MessageType::Method)
+        | Ok(MessageType::Join)
+        | Ok(MessageType::Leave) => true,
         // Messages carrying an entity CREATE encode synchronously so a
         // freshly spawned entity reaches nearby clients on the tick it first
         // streams, instead of losing a tick to the async encode round-trip.
@@ -56,6 +62,26 @@ fn is_immediate(message: &Message) -> bool {
             .iter()
             .any(|e| EntityOperation::try_from(e.operation) == Ok(EntityOperation::Create)),
         _ => false,
+    }
+}
+
+/// World-data-plane messages ride the connection's BULK lane: they can be
+/// megabytes deep while a client streams chunks, and must never delay
+/// control-plane traffic (lifecycle, chat, live state). Load -> Update
+/// ordering is preserved within the lane, which is what keeps late voxel
+/// edits correct relative to the chunk snapshots they modify.
+fn is_bulk(msg_type: i32) -> bool {
+    matches!(
+        MessageType::try_from(msg_type),
+        Ok(MessageType::Load) | Ok(MessageType::Unload) | Ok(MessageType::Update)
+    )
+}
+
+fn send_lane_routed(client: &Client, msg_type: i32, data: Vec<u8>) {
+    if is_bulk(msg_type) {
+        let _ = client.sender.send_bulk(data);
+    } else {
+        let _ = client.sender.send(data);
     }
 }
 
@@ -256,7 +282,7 @@ impl<'a> System<'a> for BroadcastSystem {
                             }
                         }
                     }
-                    let _ = client.sender.send(encoded.data.clone());
+                    send_lane_routed(client, encoded.msg_type, encoded.data.clone());
                 }
                 let queue_depths = connection_queue_depths(&clients, &filter);
                 log_outbound_perf(&encoded, world_name, stats.tick, queue_depths);
@@ -292,7 +318,7 @@ impl<'a> System<'a> for BroadcastSystem {
                     }
                 }
 
-                let _ = client.sender.send(encoded.data.clone());
+                send_lane_routed(client, encoded.msg_type, encoded.data.clone());
             });
 
             if !transports.is_empty() && should_send_to_transport(encoded.msg_type) {
@@ -322,7 +348,11 @@ impl<'a> System<'a> for BroadcastSystem {
         for (client_id, client) in clients.iter() {
             let rtc_sender = rtc_map.as_ref().and_then(|rtc_map| rtc_map.get(client_id));
 
-            if rtc_sender.is_none() && client.sender.len() > STATE_FLUSH_MAX_SOCKET_BACKLOG {
+            // Gate on the CONTROL lane only: bulk chunk streaming must never
+            // stall live state — that starvation is what made a newcomer
+            // invisible to an existing client while it loaded chunks.
+            if rtc_sender.is_none() && client.sender.control_len() > STATE_FLUSH_MAX_SOCKET_BACKLOG
+            {
                 if replicated_state.has_pending(client_id) {
                     gated_clients += 1;
                 }

--- a/server/world/systems/peers/sending.rs
+++ b/server/world/systems/peers/sending.rs
@@ -75,6 +75,13 @@ impl<'a> System<'a> for PeersSendingSystem {
             let client_pos = positions.get(client.entity).map(|p| [p.0 .0, p.0 .1, p.0 .2]);
 
             for (peer, peer_pos) in &changed {
+                // A client is authoritative over its own pose; echoing it back
+                // is wasted bandwidth and lets a buggy client create a
+                // self-peer.
+                if peer.id == *client_id {
+                    continue;
+                }
+
                 let relevant = match (config.peer_visible_radius, client_pos, peer_pos) {
                     (Some(_), Some(client_pos), Some(peer_pos)) => {
                         let dx = peer_pos[0] - client_pos[0];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problems

Four real-time failures surfaced in games built on the engine (e.g. Town). The first two are rooted in the same modeling error — **positional state was queued like events** — the third is its control-plane sibling (**JOIN treated as fire-once instead of reliable/idempotent**), and the fourth is a starvation/determinism hole found by staging fuzz (**asymmetric peer visibility**).

1. **Outbound replay / rubber-banding.** Entity updates and peer (player) position broadcasts were appended to FIFO queues (per-tick `MessageQueues` → async-encode `EncodedMessageQueue` → per-connection unbounded `mpsc` behind `WsSender`). When any stage backed up, clients received a *replay of stale frames*. A previous backpressure attempt was reverted (`6c59444f1`) because it still queued stale frames.
2. **Stale inbound player positions.** Peer packets were applied whenever their actor message happened to be handled; a `Tick` could overtake a position packet that had already arrived, so AI systems read the player's *previous* position — follower bots walked to where the player used to be.
3. **Join/reconnect loop + zombie memberships.** A JOIN whose INIT ack was delayed made the client retry; the retry hit a fatal `already in world` error, closing the socket, looping. Abruptly killed agents left half-open sockets that were never reaped, blocking same-ID reconnects.
4. **Asymmetric peer visibility (staging fuzz).** agent-4199 joins first, agent-4599 joins second; 4599 sees 4199, but 4199 never sees 4599 — `peer_batch_send` never targets the existing client. Root cause was threefold: (a) the newcomer's peer state was staged off a **one-tick metadata dirty flag** with no re-sync on membership change; (b) peer JOIN/state shared **one per-connection FIFO with bulk chunk traffic**, so lifecycle/state sat behind megabytes of queued chunk frames while the state-flush gate measured that same backlog and stayed closed; (c) the connection depth signal was decremented **before** the socket write completed, under-reporting real backlog.

## Design

New module **`server/world/replication`** makes the channel split a named, first-class engine concept:

| Channel | Semantics | Carrier |
|---|---|---|
| **Session control-plane** | the most reliable of all — JOIN/INIT-ack/LEAVE/disconnect; never gated, never coalesced, **idempotent**, immune to bulk starvation | token-checked session registry + immediate encode + per-connection **control lane** |
| **Reliable ordered events** | must-deliver, exactly once, in order: chat, entity CREATE/DELETE/OUT_OF_RANGE, methods, events | `MessageQueues` / `EncodedMessageQueue` → control lane |
| **Reliable bulk world data** | chunk loads/unloads, voxel updates — ordered *within* the lane, megabytes-deep during loads | **bulk lane**, drained only when the control lane is empty |
| **Latest-wins state** | drop-old-ok samples: entity UPDATEs, peer position/metadata | new `ReplicatedStateBuffer` → control lane, gated on control-lane depth |

### Per-connection priority lanes (fixes starvation)
`WsSender` now carries two channels; the connection's write loop uses a `biased` select so **control traffic is always written before queued bulk data**. A client streaming megabytes of chunks still receives JOIN/LEAVE, chat, and live entity/peer state promptly (verified: LEAVE lands 15ms after socket resume with a full chunk backlog queued). `Load → Update` ordering is preserved within the bulk lane, which is what keeps late voxel edits correct relative to chunk snapshots. JOIN/LEAVE additionally encode synchronously (same tick) instead of riding the async encode round-trip.

### Deterministic bidirectional peer visibility
`World::add_client` now **marks every client's peer metadata dirty** on membership change, forcing the next peers-sending run to stage a full everyone-to-everyone snapshot. Visibility no longer depends on the newcomer's single dirty tick firing at the right moment: the newcomer receives all existing peers' state (in addition to the INIT peer list), and every existing client receives the newcomer's state, within one tick, exactly once (JOIN dedupe verified). Peer snapshots are no longer echoed back to their own client (a client is authoritative over its own pose).

### Outbound: `ReplicatedStateBuffer`
- Per-client, **per-item latest-value slots**: staging a newer value overwrites the undelivered one — never appends. The module docs spell out why this must never become a FIFO again.
- **Bounded by construction** (clients × interest set) plus a hard per-client cap with a drop counter.
- Flushed by `BroadcastSystem` after reliable sends (same-tick CREATE precedes first UPDATE), stamped with the server tick for client interpolation.
- **Gate on the control-lane depth, decremented only after the socket write completes**: bulk chunk streaming never gates live state; a genuinely stalled socket (peer stopped reading) climbs the control depth, state coalesces in slots, and the client receives one current snapshot when it drains. Stalled writes are bounded (15s) and dead sockets heartbeat-reaped, so gated slots can't linger forever.
- Lifecycle transitions clear pending slots (no resurrection); a departing client's peer snapshots are purged before LEAVE (verified: no stale peer state delivered after a LEAVE).

### Inbound: `InboundStateBuffer` (drain-before-dispatch)
Peer packets bypass the world's actor mailbox into a shared buffer drained at the very start of `world.tick()`, before `dispatcher.dispatch()` — every packet that arrived before the tick began is visible to every system in that tick. The `MAX_PEER_POS_DELTA` clamp and custom game parsers are untouched; per-client "position-then-command" ordering is preserved; bounded per client.

### Session lifecycle: idempotent JOIN, token-checked sockets, dead-socket reaping
- JOIN retries replay the INIT ack (`Server::on_join` → idempotent `World::add_client`): no `already in world` loops, no duplicate entities. JOIN for a different world is an atomic switch.
- Connection tokens ride in `ClientMessage`; superseded sockets are rejected (`session_superseded`) and cannot cross-wire a replacement session.
- Heartbeat (`VOXELIZE_WS_HEARTBEAT_MS`) + idle timeout (`VOXELIZE_WS_CLIENT_TIMEOUT_MS`) + bounded writes reap abrupt closures; cleanup removes membership, entity, and all replication buffers deterministically.

### Interest management & interpolation
Entity interest machinery unified into `world/replication/interest.rs`; peers gain opt-in radius relevance (`peer_visible_radius`, default unlimited). New `uint64 tick = 12` protobuf field stamps all state messages (wire-compatible).

## Engine-boundary cleanliness
No game logic; public API compatible except: `ClientMessage::new` gained `session_token: Option<String>`, and `WsSender::new` now takes the two lane senders (both internal plumbing types games don't construct). Optional opt-ins: `peer_visible_radius`, `message.tick`, `VOXELIZE_WS_*` env knobs.

## Observability (for staging fuzz)
`TOWN_PERF_LOG` emits `client_join` (`outcome: created|replayed`, `connectedClients`), `client_leave`, `client_join_replayed`, `session_replaced`, `session_superseded`; `core_tick` reports `stateSlotDepth`, `stateGatedClients`, `stateDroppedUpdates`, `inboundStateDropped`; `entity_batch_send`/`peer_batch_send` carry per-connection depths. A join-loop shows as repeated `created`/`leave` cycles; a healthy retry as `replayed` with stable `connectedClients`; visibility asymmetry as missing `peer_batch_send` for one client.

## Also fixed
Default dispatcher registered `entities-meta` before its `physics` dependency (pre-existing shred panic at dispatcher build, verified on base).

## Verification

- ✅ `cargo check` — no new warnings (85 vs 86 baseline)
- ✅ `cargo build --release`
- ✅ `cargo test` — 64 tests: 10 replication unit tests, 7 session-lifecycle integration tests (real `Server` + `SyncWorld`, fake sockets) including the new **bidirectional visibility test**: A joins, B joins → A gets exactly one JOIN + B's state, B's INIT lists A + A's state, no self peer; B moves → A converges; with A's connection deliberately backlogged past the gate, B's LEAVE still arrives and no stale B state follows it
- ✅ Visibility e2e (13/13): sequential joins over the real wire protocol — A learns B via reliable JOIN + peer state, B's INIT lists A, movement converges both ways, a backlogged client (paused socket + queued chunk flood) still receives JOIN/LEAVE for a third client **15ms after resume, ahead of the queued bulk chunks**, state never regresses, LEAVE removes the peer
- ✅ Replication e2e (17/17): sub-tick coalescing, monotonic tick stamps, CREATE-before-UPDATE, 200/200 large chats in order through full backpressure, slow client lands on the newest position, teleport clamp intact
- ✅ Lifecycle e2e (12/12): JOIN retry replay, socket race, abrupt reconnect, dead-socket reaping, post-reap rejoin

[e2e_visibility_test_output.log](https://cursor.com/artifacts/c/art-c364abbc-6b0a-4867-8413-aa9c290a4ce2)
[e2e_replication_test_output.log](https://cursor.com/artifacts/c/art-45de3af1-1393-42b8-a60e-15e18d50e19c)
[e2e_lifecycle_test_output.log](https://cursor.com/artifacts/c/art-48e3ba9f-8d79-4446-86d1-614897e5115d)
[perf_lifecycle_events.jsonl](https://cursor.com/artifacts/c/art-6e15e6ca-06aa-4aed-b111-474fb8769687)
[perf_log_excerpt.jsonl](https://cursor.com/artifacts/c/art-6c5e49c7-2938-49e8-b494-d0c576910e55)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34c59d5f-bd98-4db2-a84b-80a6365e492b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34c59d5f-bd98-4db2-a84b-80a6365e492b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

