### PR TITLE
feat(agent): capture-only high-res viewport and truthful /healthz liveness

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,0 +1,71 @@
+# @voxelize/agent
+
+Headless puppeteer-backed agent SDK for Voxelize worlds. Launches a browser
+that joins a world as a player, exposes an in-page control bridge, and serves
+an HTTP daemon for driving the agent from scripts.
+
+## Quick start
+
+```bash
+pnpm dev -- --url http://localhost:3000 --world terrain --port 4099
+```
+
+See `voxelize-agent --help` for all flags. The daemon listens on
+`http://127.0.0.1:<port>` and exposes routes such as `/healthz`, `/me`,
+`/snapshot`, `/screenshot`, `/act`, `/entities`, and `/events`.
+
+## Screenshots
+
+`GET /screenshot` returns a PNG of the page. Query parameters:
+
+| Parameter | Meaning |
+| --- | --- |
+| `pure` | `true`/`1` hides HUD overlays and returns only the WebGL canvas. |
+| `width` | Capture-only viewport width in CSS pixels (integer, max 7680). |
+| `height` | Capture-only viewport height in CSS pixels (integer, max 7680). |
+| `scale` | Capture-only device scale factor (max 4). |
+
+Without `width`/`height`/`scale`, the page is captured as-is at its current
+viewport (1280x720 by default, configurable via `AGENT_VIEWPORT_WIDTH`,
+`AGENT_VIEWPORT_HEIGHT`, and `AGENT_VIEWPORT_SCALE`).
+
+### High-resolution captures
+
+When any of `width`, `height`, or `scale` is passed, the page is resized for
+that single capture and restored immediately afterwards (missing values fall
+back to the current viewport). The final canvas backing store is
+`width*scale` x `height*scale`, capped at 8K UHD (7680x4320 = 33,177,600
+pixels).
+
+```bash
+# 3840x2160 (4K) backing canvas, pure WebGL frame:
+curl 'http://127.0.0.1:4099/screenshot?pure=true&width=2560&height=1440&scale=1.5' -o shot.png
+```
+
+Invalid values (non-numeric, non-positive, fractional dimensions, or anything
+over the caps) return HTTP 400 with an error message.
+
+Why a temporary resize instead of running the browser at 4K? Under software
+WebGL, every frame at 4K is roughly 9x the raster work of 720p. Heavy worlds
+already saturate the main thread while streaming chunks during join/load, so
+a permanently large viewport starves the network and chunk pipelines: the
+agent stalls, misses pings, and can get disconnected. Joining at the
+lightweight default viewport and only paying for high resolution inside the
+capture window keeps the session healthy while still producing pure 4K (or up
+to 8K) frames on demand.
+
+The capture waits for the app to react to the resize (the canvas backing
+store reaching the expected size, then a double `requestAnimationFrame`) both
+after the resize and after the restoration, and the original viewport is
+restored even if the capture fails.
+
+The same options are available programmatically:
+
+```ts
+const png = await agent.screenshot({
+  isPure: true,
+  width: 2560,
+  height: 1440,
+  deviceScaleFactor: 1.5,
+});
+```

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -14,6 +14,31 @@ See `voxelize-agent --help` for all flags. The daemon listens on
 `http://127.0.0.1:<port>` and exposes routes such as `/healthz`, `/me`,
 `/snapshot`, `/screenshot`, `/act`, `/entities`, and `/events`.
 
+## Health
+
+`GET /healthz` reflects the real liveness of the whole chain, not just the
+HTTP listener. It returns `200` with `{"ok": true, ...}` only when all of the
+following hold:
+
+- the browser process is alive and the DevTools connection is up,
+- the page is open,
+- the in-page agent bridge is installed and ready,
+- the world snapshot (queried with a 3s timeout) reports ready.
+
+Otherwise it returns `503` with `ok: false` and a `reasons` array naming each
+failure (for example `"browser process is dead (pid 1234)"`), plus the raw
+`browser`/`page`/`bridge`/`world` state. This exists because a killed browser
+under a still-listening daemon used to keep answering `{ok:true}` forever, so
+supervisors like PM2 never restarted the wrapper even though the agent had
+been disconnected from the world.
+
+The `voxelize-agent` wrapper also exits with code 1 when the browser
+disconnects unexpectedly (process death, DevTools connection loss), so
+PM2/systemd restart it instead of keeping a stale listener. Graceful
+shutdowns (SIGINT/SIGTERM/SIGHUP, `agent.close()`) still exit 0. The same
+signals are available programmatically via `agent.health()` and
+`agent.onUnexpectedDisconnect(cb)`.
+
 ## Screenshots
 
 `GET /screenshot` returns a PNG of the page. Query parameters:

--- a/packages/agent/bin/voxelize-agent.ts
+++ b/packages/agent/bin/voxelize-agent.ts
@@ -45,16 +45,10 @@ async function main(): Promise<void> {
     agent.killBrowserSync();
   });
 
-  console.log("[voxelize-agent] browser launched, awaiting ready...");
-  await agent.ready();
-  console.log("[voxelize-agent] agent ready");
-
   const daemon = new AgentDaemon({ agent, port });
-  await daemon.start(port);
-  console.log(`[voxelize-agent] daemon listening on http://127.0.0.1:${port}`);
 
   let isShuttingDown = false;
-  const shutdown = async (reason: string) => {
+  const shutdown = async (reason: string, exitCode: number) => {
     if (isShuttingDown) return;
     isShuttingDown = true;
     console.log(`[voxelize-agent] shutting down (${reason})...`);
@@ -68,20 +62,32 @@ async function main(): Promise<void> {
     } catch (e) {
       console.error(e);
     }
-    process.exit(0);
+    process.exit(exitCode);
   };
 
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
-    process.on(signal, () => void shutdown(signal));
+    process.on(signal, () => void shutdown(signal, 0));
   }
   process.on("uncaughtException", (err) => {
     console.error("[voxelize-agent] uncaught exception:", err);
-    void shutdown("uncaughtException");
+    void shutdown("uncaughtException", 1);
   });
   process.on("unhandledRejection", (reason) => {
     console.error("[voxelize-agent] unhandled rejection:", reason);
-    void shutdown("unhandledRejection");
+    void shutdown("unhandledRejection", 1);
   });
+
+  // A browser that dies underneath us leaves the HTTP listener alive but
+  // useless; exit nonzero so PM2/systemd restart the whole wrapper. Graceful
+  // close() suppresses this, so signal-driven shutdowns still exit 0.
+  agent.onUnexpectedDisconnect((reason) => void shutdown(reason, 1));
+
+  console.log("[voxelize-agent] browser launched, awaiting ready...");
+  await agent.ready();
+  console.log("[voxelize-agent] agent ready");
+
+  await daemon.start(port);
+  console.log(`[voxelize-agent] daemon listening on http://127.0.0.1:${port}`);
 }
 
 function printHelp(): void {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -36,6 +36,7 @@
     "compile": "vite build",
     "build": "pnpm run clean && pnpm run compile && pnpm run types",
     "types": "tsc --emitDeclarationOnly --outDir ./dist -p ./tsconfig.json --declaration",
+    "test": "vitest --run",
     "dev": "tsx bin/voxelize-agent.ts"
   },
   "dependencies": {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -40,6 +40,7 @@ import {
   expectedBackingSize,
   resolveCaptureViewport,
 } from "./capture-viewport";
+import { AgentHealth, AgentWorldHealth, evaluateAgentHealth } from "./health";
 import {
   createAgentPerfTraceId,
   isAgentPerfLogging,
@@ -93,6 +94,7 @@ const DEFAULT_DAEMON_PORT = 4099;
 const BROWSER_CLOSE_TIMEOUT_MS = 1500;
 const ENTITY_ACCESS_TIMEOUT_MS = 5000;
 const CAPTURE_RESIZE_PAINT_TIMEOUT_MS = 15_000;
+const HEALTH_SNAPSHOT_TIMEOUT_MS = 3_000;
 
 function positiveEnvNumber(name: string, fallback: number): number {
   const value = Number(process.env[name]);
@@ -107,6 +109,11 @@ export class Agent {
   private eventListeners: Map<AgentEventName, Set<(data: unknown) => void>> =
     new Map();
   private chatLog: ChatMsgIn[] = [];
+  private isClosing = false;
+  private isBridgeReady = false;
+  private bridgeError: string | null = null;
+  private unexpectedDisconnectReason: string | null = null;
+  private disconnectListeners = new Set<(reason: string) => void>();
   public readyPromise: Promise<void>;
 
   private constructor(
@@ -164,6 +171,7 @@ export class Agent {
     }, port);
 
     const agent = new Agent(browser, page, Promise.resolve(), pidFile, world);
+    browser.on("disconnected", () => agent.handleBrowserDisconnected());
     agent.attachPageLogging(page);
     await agent.installChatCapture();
 
@@ -194,8 +202,47 @@ export class Agent {
 
     const ready = Agent.waitForBridge(page, waitReadyTimeoutMs);
 
-    agent.readyPromise = ready;
+    agent.trackReadyPromise(ready);
     return agent;
+  }
+
+  private trackReadyPromise(ready: Promise<void>): void {
+    this.readyPromise = ready;
+    this.isBridgeReady = false;
+    this.bridgeError = null;
+    ready.then(
+      () => {
+        if (this.readyPromise === ready) this.isBridgeReady = true;
+      },
+      (error: Error) => {
+        if (this.readyPromise === ready) this.bridgeError = error.message;
+      },
+    );
+  }
+
+  private handleBrowserDisconnected(): void {
+    // Expected during close()/killBrowserSync(); anything else means the
+    // browser process died or the DevTools connection dropped underneath a
+    // still-running daemon, which supervisors must be able to observe.
+    if (this.isClosing) return;
+    const reason =
+      "browser disconnected unexpectedly (process died or connection lost)";
+    this.unexpectedDisconnectReason = reason;
+    console.error(`[voxelize-agent] ${reason}`);
+    for (const cb of this.disconnectListeners) {
+      try {
+        cb(reason);
+      } catch (e) {
+        console.error("[voxelize-agent] disconnect listener error:", e);
+      }
+    }
+  }
+
+  onUnexpectedDisconnect(cb: (reason: string) => void): () => void {
+    this.disconnectListeners.add(cb);
+    return () => {
+      this.disconnectListeners.delete(cb);
+    };
   }
 
   private static async waitForBridge(
@@ -280,7 +327,7 @@ export class Agent {
       }
     }
     const ready = Agent.waitForBridge(this.page, waitReadyTimeoutMs);
-    this.readyPromise = ready;
+    this.trackReadyPromise(ready);
     await ready;
   }
 
@@ -311,6 +358,7 @@ export class Agent {
   }
 
   async close(): Promise<void> {
+    this.isClosing = true;
     const proc = this.browser.process();
     try {
       await Promise.race([
@@ -338,6 +386,7 @@ export class Agent {
   }
 
   killBrowserSync(): void {
+    this.isClosing = true;
     try {
       this.browser.process()?.kill("SIGKILL");
     } catch {
@@ -530,6 +579,70 @@ export class Agent {
 
   async snapshot(): Promise<Snapshot> {
     return this.page.evaluate(() => window.__agentRequired__().snapshot());
+  }
+
+  async health(): Promise<AgentHealth> {
+    const proc = this.browser.process();
+    const isBrowserProcessAlive =
+      proc === null ? null : proc.exitCode === null && proc.signalCode === null;
+    const isBrowserConnected = this.browser.connected;
+    const isPageOpen = !this.page.isClosed();
+
+    // Only query the page when the whole transport chain is alive; evaluating
+    // against a dead browser would hang or throw instead of reporting.
+    let world: AgentWorldHealth = {
+      name: this.worldName,
+      isReady: null,
+      error: null,
+    };
+    if (
+      isBrowserConnected &&
+      isPageOpen &&
+      this.isBridgeReady &&
+      isBrowserProcessAlive !== false
+    ) {
+      let timeout: NodeJS.Timeout | undefined;
+      try {
+        const snapshot = await Promise.race([
+          this.snapshot(),
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `snapshot timed out after ${HEALTH_SNAPSHOT_TIMEOUT_MS}ms`,
+                  ),
+                ),
+              HEALTH_SNAPSHOT_TIMEOUT_MS,
+            );
+          }),
+        ]);
+        world = {
+          name: snapshot.world || this.worldName,
+          isReady: snapshot.isReady,
+          error: null,
+        };
+      } catch (error) {
+        world = {
+          name: this.worldName,
+          isReady: null,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    }
+
+    return evaluateAgentHealth({
+      isBrowserConnected,
+      isBrowserProcessAlive,
+      browserPid: proc?.pid ?? null,
+      isPageOpen,
+      isBridgeReady: this.isBridgeReady,
+      bridgeError: this.bridgeError,
+      unexpectedDisconnectReason: this.unexpectedDisconnectReason,
+      world,
+    });
   }
 
   async chunkState(target: Vec3 | ChunkCoord): Promise<ChunkState> {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -36,6 +36,11 @@ import {
   recordAgentBrowser,
 } from "./browser-lifecycle";
 import {
+  CaptureViewport,
+  expectedBackingSize,
+  resolveCaptureViewport,
+} from "./capture-viewport";
+import {
   createAgentPerfTraceId,
   isAgentPerfLogging,
   logAgentPerf,
@@ -65,11 +70,29 @@ export type ScreenshotOptions = {
    * WebGL canvas instead of the full page.
    */
   isPure?: boolean;
+  /**
+   * Optional capture-only viewport width in CSS pixels. When any of width,
+   * height, or deviceScaleFactor is set, the page is temporarily resized for
+   * this one capture and restored afterwards. This keeps join/load running at
+   * the lightweight default viewport: heavy worlds under software WebGL stall
+   * (and can drop the websocket) when the whole session renders at 4K, so
+   * high resolution is paid for only during the capture itself.
+   */
+  width?: number;
+  /** Optional capture-only viewport height in CSS pixels. */
+  height?: number;
+  /**
+   * Optional capture-only device scale factor. The canvas backing store ends
+   * up at width*deviceScaleFactor x height*deviceScaleFactor, e.g.
+   * 2560x1440 at 1.5 yields a 3840x2160 (4K) capture.
+   */
+  deviceScaleFactor?: number;
 };
 
 const DEFAULT_DAEMON_PORT = 4099;
 const BROWSER_CLOSE_TIMEOUT_MS = 1500;
 const ENTITY_ACCESS_TIMEOUT_MS = 5000;
+const CAPTURE_RESIZE_PAINT_TIMEOUT_MS = 15_000;
 
 function positiveEnvNumber(name: string, fallback: number): number {
   const value = Number(process.env[name]);
@@ -544,7 +567,36 @@ export class Agent {
   }
 
   async screenshot(opts: ScreenshotOptions = {}): Promise<Buffer> {
-    if (opts.isPure) {
+    const current = this.page.viewport();
+    const currentViewport: CaptureViewport = {
+      width: current?.width ?? 1280,
+      height: current?.height ?? 720,
+      deviceScaleFactor: current?.deviceScaleFactor || 1,
+    };
+    // Throws CaptureViewportError for out-of-range requests; the daemon maps
+    // that to an HTTP 400 before the page is touched at all.
+    const captureViewport = resolveCaptureViewport(opts, currentViewport);
+    if (!captureViewport) {
+      return this.captureBuffer(opts.isPure === true);
+    }
+
+    // Resize only for the duration of this capture. Joining/loading at 4K
+    // under software WebGL makes every frame so expensive that heavy worlds
+    // (e.g. large town hubs) starve the network/chunk pipeline and the agent
+    // stalls or disconnects. Loading at the lightweight default viewport and
+    // paying for high resolution only inside this window avoids that.
+    await this.setViewportAndAwaitPaint(captureViewport);
+    try {
+      return await this.captureBuffer(opts.isPure === true);
+    } finally {
+      // Restore even when the capture throws, and wait for the restoration
+      // paint too, so the session never keeps running at capture resolution.
+      await this.setViewportAndAwaitPaint(currentViewport);
+    }
+  }
+
+  private async captureBuffer(isPure: boolean): Promise<Buffer> {
+    if (isPure) {
       const dataUrl = await this.page.evaluate(
         (o) => window.__agentRequired__().captureFrame(o),
         { isPure: true },
@@ -562,6 +614,48 @@ export class Agent {
       fullPage: false,
     });
     return Buffer.from(result);
+  }
+
+  private async setViewportAndAwaitPaint(
+    viewport: CaptureViewport,
+  ): Promise<void> {
+    await this.page.setViewport(viewport);
+
+    // Wait until the app has reacted to the resize and the WebGL canvas
+    // backing store reaches the expected size. A 1px tolerance absorbs
+    // floor/round differences between renderers. Timing out is downgraded to
+    // a warning: a renderer that clamps its pixel ratio would otherwise make
+    // captures fail forever, and a slightly-off frame beats no frame.
+    const expected = expectedBackingSize(viewport);
+    try {
+      await this.page.waitForFunction(
+        (w, h) => {
+          const canvases = Array.from(document.querySelectorAll("canvas"));
+          return canvases.some(
+            (canvas) =>
+              Math.abs(canvas.width - w) <= 1 &&
+              Math.abs(canvas.height - h) <= 1,
+          );
+        },
+        { timeout: CAPTURE_RESIZE_PAINT_TIMEOUT_MS, polling: "raf" },
+        expected.width,
+        expected.height,
+      );
+    } catch {
+      console.warn(
+        `[voxelize-agent] canvas did not reach ${expected.width}x${expected.height} ` +
+          `within ${CAPTURE_RESIZE_PAINT_TIMEOUT_MS}ms after viewport resize; capturing anyway`,
+      );
+    }
+
+    // Double requestAnimationFrame guarantees at least one full frame has
+    // been rendered and presented at the new backing size before capture.
+    await this.page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
   }
 
   async measureFrameRate(

--- a/packages/agent/src/capture-viewport.test.ts
+++ b/packages/agent/src/capture-viewport.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CaptureViewport,
+  CaptureViewportError,
+  expectedBackingSize,
+  MAX_CAPTURE_BACKING_PIXELS,
+  MAX_CAPTURE_DIMENSION,
+  MAX_CAPTURE_SCALE,
+  parseCaptureViewportQuery,
+  resolveCaptureViewport,
+} from "./capture-viewport";
+
+const current: CaptureViewport = {
+  width: 1280,
+  height: 720,
+  deviceScaleFactor: 1,
+};
+
+describe("parseCaptureViewportQuery", () => {
+  it("returns all-undefined when no fields are present", () => {
+    expect(parseCaptureViewportQuery({})).toEqual({
+      width: undefined,
+      height: undefined,
+      deviceScaleFactor: undefined,
+    });
+  });
+
+  it("parses numeric strings", () => {
+    expect(
+      parseCaptureViewportQuery({
+        width: "2560",
+        height: "1440",
+        scale: "1.5",
+      }),
+    ).toEqual({ width: 2560, height: 1440, deviceScaleFactor: 1.5 });
+  });
+
+  it("parses a subset of fields", () => {
+    expect(parseCaptureViewportQuery({ scale: "3" })).toEqual({
+      width: undefined,
+      height: undefined,
+      deviceScaleFactor: 3,
+    });
+  });
+
+  it.each([
+    ["width", { width: "abc" }],
+    ["width", { width: "" }],
+    ["width", { width: "  " }],
+    ["height", { height: "12px" }],
+    ["height", { height: "NaN" }],
+    ["scale", { scale: "Infinity" }],
+    ["scale", { scale: "1.5x" }],
+  ])("rejects non-numeric %s", (field, query) => {
+    expect(() => parseCaptureViewportQuery(query)).toThrowError(
+      CaptureViewportError,
+    );
+    expect(() => parseCaptureViewportQuery(query)).toThrowError(
+      new RegExp(`^${field} `),
+    );
+  });
+});
+
+describe("resolveCaptureViewport", () => {
+  it("returns null when nothing is requested", () => {
+    expect(resolveCaptureViewport({}, current)).toBeNull();
+  });
+
+  it("resolves a full request", () => {
+    expect(
+      resolveCaptureViewport(
+        { width: 2560, height: 1440, deviceScaleFactor: 1.5 },
+        current,
+      ),
+    ).toEqual({ width: 2560, height: 1440, deviceScaleFactor: 1.5 });
+  });
+
+  it("falls back to the current viewport for missing fields", () => {
+    expect(resolveCaptureViewport({ deviceScaleFactor: 3 }, current)).toEqual({
+      width: 1280,
+      height: 720,
+      deviceScaleFactor: 3,
+    });
+    expect(resolveCaptureViewport({ width: 1920 }, current)).toEqual({
+      width: 1920,
+      height: 720,
+      deviceScaleFactor: 1,
+    });
+  });
+
+  it("accepts the documented 4K example", () => {
+    const viewport = resolveCaptureViewport(
+      { width: 2560, height: 1440, deviceScaleFactor: 1.5 },
+      current,
+    );
+    expect(viewport).not.toBeNull();
+    expect(expectedBackingSize(viewport as CaptureViewport)).toEqual({
+      width: 3840,
+      height: 2160,
+    });
+  });
+
+  it("accepts the maximum 8K budget exactly", () => {
+    expect(
+      resolveCaptureViewport(
+        { width: 7680, height: 4320, deviceScaleFactor: 1 },
+        current,
+      ),
+    ).toEqual({ width: 7680, height: 4320, deviceScaleFactor: 1 });
+  });
+
+  it.each([
+    ["zero width", { width: 0 }],
+    ["negative width", { width: -100 }],
+    ["NaN width", { width: Number.NaN }],
+    ["infinite width", { width: Number.POSITIVE_INFINITY }],
+    ["fractional width", { width: 1280.5 }],
+    ["oversized width", { width: MAX_CAPTURE_DIMENSION + 1 }],
+    ["zero height", { height: 0 }],
+    ["negative height", { height: -1 }],
+    ["fractional height", { height: 719.9 }],
+    ["oversized height", { height: MAX_CAPTURE_DIMENSION + 1 }],
+    ["zero scale", { deviceScaleFactor: 0 }],
+    ["negative scale", { deviceScaleFactor: -2 }],
+    ["NaN scale", { deviceScaleFactor: Number.NaN }],
+    ["oversized scale", { deviceScaleFactor: MAX_CAPTURE_SCALE + 0.01 }],
+  ])("rejects %s", (_label, requested) => {
+    expect(() => resolveCaptureViewport(requested, current)).toThrowError(
+      CaptureViewportError,
+    );
+  });
+
+  it("rejects captures whose backing pixels exceed the 8K budget", () => {
+    expect(() =>
+      resolveCaptureViewport(
+        { width: 7680, height: 4320, deviceScaleFactor: 1.01 },
+        current,
+      ),
+    ).toThrowError(/exceeding the maximum/);
+    expect(() =>
+      resolveCaptureViewport(
+        { width: 5000, height: 5000, deviceScaleFactor: 1.2 },
+        current,
+      ),
+    ).toThrowError(CaptureViewportError);
+  });
+
+  it("keeps the backing budget consistent with the exported constant", () => {
+    expect(MAX_CAPTURE_BACKING_PIXELS).toBe(7680 * 4320);
+  });
+});
+
+describe("expectedBackingSize", () => {
+  it("floors fractional products like renderers do", () => {
+    expect(
+      expectedBackingSize({ width: 1111, height: 733, deviceScaleFactor: 1.5 }),
+    ).toEqual({ width: 1666, height: 1099 });
+  });
+});

--- a/packages/agent/src/capture-viewport.ts
+++ b/packages/agent/src/capture-viewport.ts
@@ -1,0 +1,147 @@
+export type CaptureViewport = {
+  width: number;
+  height: number;
+  deviceScaleFactor: number;
+};
+
+export type RequestedCaptureViewport = Partial<CaptureViewport>;
+
+// 8K UHD (7680x4320) is the ceiling for a single capture. Backing pixels are
+// what actually cost memory and encode time under software WebGL, so the
+// combined (width*scale) x (height*scale) budget is capped rather than each
+// dimension alone.
+export const MAX_CAPTURE_DIMENSION = 7680;
+export const MAX_CAPTURE_SCALE = 4;
+export const MAX_CAPTURE_BACKING_PIXELS = 7680 * 4320;
+
+export class CaptureViewportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CaptureViewportError";
+  }
+}
+
+function requireDimension(name: "width" | "height", value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new CaptureViewportError(
+      `${name} must be a finite number, got ${String(value)}`,
+    );
+  }
+  if (!Number.isInteger(value)) {
+    throw new CaptureViewportError(
+      `${name} must be an integer number of CSS pixels, got ${value}`,
+    );
+  }
+  if (value <= 0) {
+    throw new CaptureViewportError(`${name} must be positive, got ${value}`);
+  }
+  if (value > MAX_CAPTURE_DIMENSION) {
+    throw new CaptureViewportError(
+      `${name} must be at most ${MAX_CAPTURE_DIMENSION}, got ${value}`,
+    );
+  }
+  return value;
+}
+
+function requireScale(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new CaptureViewportError(
+      `deviceScaleFactor must be a finite number, got ${String(value)}`,
+    );
+  }
+  if (value <= 0) {
+    throw new CaptureViewportError(
+      `deviceScaleFactor must be positive, got ${value}`,
+    );
+  }
+  if (value > MAX_CAPTURE_SCALE) {
+    throw new CaptureViewportError(
+      `deviceScaleFactor must be at most ${MAX_CAPTURE_SCALE}, got ${value}`,
+    );
+  }
+  return value;
+}
+
+export function expectedBackingSize(viewport: CaptureViewport): {
+  width: number;
+  height: number;
+} {
+  // Renderers floor fractional CSS-pixel * scale products (three.js does),
+  // so the expected canvas backing store is the floored product.
+  return {
+    width: Math.floor(viewport.width * viewport.deviceScaleFactor),
+    height: Math.floor(viewport.height * viewport.deviceScaleFactor),
+  };
+}
+
+export function resolveCaptureViewport(
+  requested: RequestedCaptureViewport,
+  current: CaptureViewport,
+): CaptureViewport | null {
+  // Null means "no viewport override requested": the screenshot should use
+  // the page exactly as it is. Missing fields fall back to the current
+  // viewport so callers can e.g. only bump the scale. Invalid values throw
+  // CaptureViewportError so HTTP callers can map them to a 400.
+  if (
+    requested.width === undefined &&
+    requested.height === undefined &&
+    requested.deviceScaleFactor === undefined
+  ) {
+    return null;
+  }
+
+  const viewport: CaptureViewport = {
+    width: requireDimension("width", requested.width ?? current.width),
+    height: requireDimension("height", requested.height ?? current.height),
+    deviceScaleFactor: requireScale(
+      requested.deviceScaleFactor ?? current.deviceScaleFactor,
+    ),
+  };
+
+  const backing = expectedBackingSize(viewport);
+  const backingPixels = backing.width * backing.height;
+  if (backingPixels > MAX_CAPTURE_BACKING_PIXELS) {
+    throw new CaptureViewportError(
+      `requested capture is ${backing.width}x${backing.height} backing pixels ` +
+        `(${backingPixels}), exceeding the maximum of ${MAX_CAPTURE_BACKING_PIXELS} (8K UHD)`,
+    );
+  }
+
+  return viewport;
+}
+
+function parseQueryNumber(name: string, raw: string): number {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    throw new CaptureViewportError(`${name} must be a number, got ""`);
+  }
+  const value = Number(trimmed);
+  if (!Number.isFinite(value)) {
+    throw new CaptureViewportError(`${name} must be a number, got "${raw}"`);
+  }
+  return value;
+}
+
+export function parseCaptureViewportQuery(query: {
+  width?: string;
+  height?: string;
+  scale?: string;
+}): RequestedCaptureViewport {
+  // Only syntactic parsing happens here; range validation lives in
+  // resolveCaptureViewport. Non-numeric input throws CaptureViewportError so
+  // the daemon can respond with a 400 instead of silently accepting it.
+  return {
+    width:
+      query.width !== undefined
+        ? parseQueryNumber("width", query.width)
+        : undefined,
+    height:
+      query.height !== undefined
+        ? parseQueryNumber("height", query.height)
+        : undefined,
+    deviceScaleFactor:
+      query.scale !== undefined
+        ? parseQueryNumber("scale", query.scale)
+        : undefined,
+  };
+}

--- a/packages/agent/src/daemon.ts
+++ b/packages/agent/src/daemon.ts
@@ -147,7 +147,17 @@ export class AgentDaemon {
   }
 
   private registerRoutes(): void {
-    this.server.get("/healthz", async () => ({ ok: true }));
+    // Liveness must reflect the real browser/page/bridge chain: a killed
+    // browser under a still-listening daemon previously kept returning
+    // {ok:true} forever, so PM2 never restarted the wrapper even though the
+    // agent was disconnected from the world.
+    this.server.get("/healthz", async (_req, reply) => {
+      const health = await this.agent.health();
+      if (!health.isHealthy) {
+        reply.code(503);
+      }
+      return { ok: health.isHealthy, ...health };
+    });
 
     this.server.get("/me", async () => {
       const [position, facing] = await Promise.all([
@@ -372,7 +382,9 @@ export class AgentDaemon {
         await this.agent.setFlying(action.isFlying);
         return { flying: action.isFlying };
       case "set-render-radius":
-        return { renderRadius: await this.agent.setRenderRadius(action.radius) };
+        return {
+          renderRadius: await this.agent.setRenderRadius(action.radius),
+        };
       case "call":
         return this.agent.call(action.method, action.payload);
       case "wait":

--- a/packages/agent/src/daemon.ts
+++ b/packages/agent/src/daemon.ts
@@ -4,6 +4,10 @@ import { z } from "zod";
 import { Agent } from "./agent";
 import type { AgentEventMap } from "./bridge";
 import {
+  CaptureViewportError,
+  parseCaptureViewportQuery,
+} from "./capture-viewport";
+import {
   createAgentPerfTraceId,
   isAgentPerfLogging,
   logAgentPerf,
@@ -155,15 +159,32 @@ export class AgentDaemon {
 
     this.server.get("/snapshot", async () => this.agent.snapshot());
 
-    this.server.get<{ Querystring: { pure?: string } }>(
-      "/screenshot",
-      async (req, reply) => {
-        const isPure = req.query.pure === "true" || req.query.pure === "1";
-        const buffer = await this.agent.screenshot({ isPure });
+    // Optional width/height (CSS px) and scale (device scale factor) resize
+    // the page for this one capture only and restore it afterwards. Example:
+    // /screenshot?pure=true&width=2560&height=1440&scale=1.5 renders a
+    // 3840x2160 (4K) backing canvas without the session ever loading at 4K.
+    this.server.get<{
+      Querystring: {
+        pure?: string;
+        width?: string;
+        height?: string;
+        scale?: string;
+      };
+    }>("/screenshot", async (req, reply) => {
+      const isPure = req.query.pure === "true" || req.query.pure === "1";
+      try {
+        const requested = parseCaptureViewportQuery(req.query);
+        const buffer = await this.agent.screenshot({ isPure, ...requested });
         reply.header("content-type", "image/png");
         return buffer;
-      },
-    );
+      } catch (e) {
+        if (e instanceof CaptureViewportError) {
+          reply.code(400);
+          return { ok: false, error: e.message };
+        }
+        throw e;
+      }
+    });
 
     this.server.get<{
       Querystring: { durationMs?: string; warmupMs?: string };

--- a/packages/agent/src/health.test.ts
+++ b/packages/agent/src/health.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import { AgentHealthInput, evaluateAgentHealth } from "./health";
+
+function healthyInput(): AgentHealthInput {
+  return {
+    isBrowserConnected: true,
+    isBrowserProcessAlive: true,
+    browserPid: 1234,
+    isPageOpen: true,
+    isBridgeReady: true,
+    bridgeError: null,
+    unexpectedDisconnectReason: null,
+    world: { name: "terrain", isReady: true, error: null },
+  };
+}
+
+describe("evaluateAgentHealth", () => {
+  it("reports healthy with no reasons when the whole chain is live", () => {
+    const health = evaluateAgentHealth(healthyInput());
+    expect(health.isHealthy).toBe(true);
+    expect(health.reasons).toEqual([]);
+    expect(health.browser).toEqual({
+      isConnected: true,
+      isProcessAlive: true,
+      pid: 1234,
+    });
+    expect(health.page).toEqual({ isOpen: true });
+    expect(health.bridge).toEqual({ isReady: true, error: null });
+    expect(health.world).toEqual({
+      name: "terrain",
+      isReady: true,
+      error: null,
+    });
+  });
+
+  it("stays healthy when the process handle is unavailable (null)", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      isBrowserProcessAlive: null,
+      browserPid: null,
+    });
+    expect(health.isHealthy).toBe(true);
+  });
+
+  it("stays healthy when the world state could not be queried but nothing failed", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      world: { name: "terrain", isReady: null, error: null },
+    });
+    expect(health.isHealthy).toBe(true);
+  });
+
+  it("is unhealthy when the browser is disconnected", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      isBrowserConnected: false,
+    });
+    expect(health.isHealthy).toBe(false);
+    expect(health.reasons).toContain("browser is not connected");
+  });
+
+  it("is unhealthy when the browser process is dead, with pid detail", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      isBrowserProcessAlive: false,
+    });
+    expect(health.isHealthy).toBe(false);
+    expect(health.reasons).toContain("browser process is dead (pid 1234)");
+  });
+
+  it("omits the pid detail when unknown", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      isBrowserProcessAlive: false,
+      browserPid: null,
+    });
+    expect(health.reasons).toContain("browser process is dead");
+  });
+
+  it("is unhealthy when the page is closed", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      isPageOpen: false,
+    });
+    expect(health.isHealthy).toBe(false);
+    expect(health.reasons).toContain("page is closed");
+  });
+
+  it("is unhealthy while the bridge is not yet ready", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      isBridgeReady: false,
+    });
+    expect(health.isHealthy).toBe(false);
+    expect(health.reasons).toContain("bridge is not ready");
+  });
+
+  it("prefers the bridge error over the generic not-ready reason", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      isBridgeReady: false,
+      bridgeError: "Timed out after 60000ms waiting for window.__agent__",
+    });
+    expect(health.reasons).toContain(
+      "bridge failed: Timed out after 60000ms waiting for window.__agent__",
+    );
+    expect(health.reasons).not.toContain("bridge is not ready");
+  });
+
+  it("surfaces an unexpected disconnect reason", () => {
+    const reason =
+      "browser disconnected unexpectedly (process died or connection lost)";
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      unexpectedDisconnectReason: reason,
+    });
+    expect(health.isHealthy).toBe(false);
+    expect(health.reasons).toContain(reason);
+  });
+
+  it("is unhealthy when the world snapshot failed", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      world: {
+        name: "terrain",
+        isReady: null,
+        error: "snapshot timed out after 3000ms",
+      },
+    });
+    expect(health.isHealthy).toBe(false);
+    expect(health.reasons).toContain(
+      "world snapshot failed: snapshot timed out after 3000ms",
+    );
+  });
+
+  it("is unhealthy when the world reports not ready", () => {
+    const health = evaluateAgentHealth({
+      ...healthyInput(),
+      world: { name: "terrain", isReady: false, error: null },
+    });
+    expect(health.isHealthy).toBe(false);
+    expect(health.reasons).toContain('world "terrain" is not ready');
+  });
+
+  it("accumulates every failure reason for a fully dead browser", () => {
+    const reason =
+      "browser disconnected unexpectedly (process died or connection lost)";
+    const health = evaluateAgentHealth({
+      isBrowserConnected: false,
+      isBrowserProcessAlive: false,
+      browserPid: 4321,
+      isPageOpen: false,
+      isBridgeReady: true,
+      bridgeError: null,
+      unexpectedDisconnectReason: reason,
+      world: { name: "terrain", isReady: null, error: null },
+    });
+    expect(health.isHealthy).toBe(false);
+    expect(health.reasons).toEqual([
+      reason,
+      "browser is not connected",
+      "browser process is dead (pid 4321)",
+      "page is closed",
+    ]);
+  });
+});

--- a/packages/agent/src/health.ts
+++ b/packages/agent/src/health.ts
@@ -1,0 +1,83 @@
+// Health semantics: the agent is healthy only when the whole chain is live —
+// browser process alive, DevTools connection up, page open, in-page bridge
+// ready, and (when obtainable) the world snapshot reporting ready. A stale
+// daemon whose browser was killed must fail /healthz so supervisors like PM2
+// restart the wrapper instead of trusting a listener that can no longer do
+// anything. The evaluation is pure so it can be tested without a browser.
+
+export type AgentWorldHealth = {
+  name: string;
+  /** Null when the snapshot could not be queried (see error). */
+  isReady: boolean | null;
+  error: string | null;
+};
+
+export type AgentHealthInput = {
+  isBrowserConnected: boolean;
+  /** Null when the browser process handle is unavailable (remote browsers). */
+  isBrowserProcessAlive: boolean | null;
+  browserPid: number | null;
+  isPageOpen: boolean;
+  isBridgeReady: boolean;
+  bridgeError: string | null;
+  unexpectedDisconnectReason: string | null;
+  world: AgentWorldHealth;
+};
+
+export type AgentHealth = {
+  isHealthy: boolean;
+  /** Empty when healthy; human-readable failure causes otherwise. */
+  reasons: string[];
+  browser: {
+    isConnected: boolean;
+    isProcessAlive: boolean | null;
+    pid: number | null;
+  };
+  page: { isOpen: boolean };
+  bridge: { isReady: boolean; error: string | null };
+  world: AgentWorldHealth;
+};
+
+export function evaluateAgentHealth(input: AgentHealthInput): AgentHealth {
+  const reasons: string[] = [];
+
+  if (input.unexpectedDisconnectReason) {
+    reasons.push(input.unexpectedDisconnectReason);
+  }
+  if (!input.isBrowserConnected) {
+    reasons.push("browser is not connected");
+  }
+  if (input.isBrowserProcessAlive === false) {
+    reasons.push(
+      input.browserPid === null
+        ? "browser process is dead"
+        : `browser process is dead (pid ${input.browserPid})`,
+    );
+  }
+  if (!input.isPageOpen) {
+    reasons.push("page is closed");
+  }
+  if (input.bridgeError) {
+    reasons.push(`bridge failed: ${input.bridgeError}`);
+  } else if (!input.isBridgeReady) {
+    reasons.push("bridge is not ready");
+  }
+  if (input.world.error) {
+    reasons.push(`world snapshot failed: ${input.world.error}`);
+  } else if (input.world.isReady === false) {
+    reasons.push(`world "${input.world.name}" is not ready`);
+  }
+
+  return {
+    isHealthy: reasons.length === 0,
+    reasons,
+    browser: {
+      isConnected: input.isBrowserConnected,
+      isProcessAlive: input.isBrowserProcessAlive,
+      pid: input.browserPid,
+    },
+    page: { isOpen: input.isPageOpen },
+    bridge: { isReady: input.isBridgeReady, error: input.bridgeError },
+    world: input.world,
+  };
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,6 +12,8 @@ export type {
   CaptureViewport,
   RequestedCaptureViewport,
 } from "./capture-viewport";
+export { evaluateAgentHealth } from "./health";
+export type { AgentHealth, AgentHealthInput, AgentWorldHealth } from "./health";
 export { AgentDaemon } from "./daemon";
 export type { DaemonEvent, DaemonOptions } from "./daemon";
 export * from "./bridge";

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,5 +1,17 @@
 export { Agent } from "./agent";
-export type { AgentLaunchOptions } from "./agent";
+export type { AgentLaunchOptions, ScreenshotOptions } from "./agent";
+export {
+  CaptureViewportError,
+  MAX_CAPTURE_BACKING_PIXELS,
+  MAX_CAPTURE_DIMENSION,
+  MAX_CAPTURE_SCALE,
+  parseCaptureViewportQuery,
+  resolveCaptureViewport,
+} from "./capture-viewport";
+export type {
+  CaptureViewport,
+  RequestedCaptureViewport,
+} from "./capture-viewport";
 export { AgentDaemon } from "./daemon";
 export type { DaemonEvent, DaemonOptions } from "./daemon";
 export * from "./bridge";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two agent-robustness fixes in `@voxelize/agent`, sharing one goal: heavy worlds under software WebGL must neither be destabilized by screenshots nor silently zombify.

### 1. High-resolution capture-only viewport

The agent joins and loads a world at the lightweight default viewport (1280x720) and only resizes the page temporarily for the duration of a single capture, restoring the original viewport afterwards.

- `ScreenshotOptions` gains optional `width`, `height`, and `deviceScaleFactor` fields.
- `GET /screenshot` gains `width`, `height`, and `scale` query parameters; invalid input (non-numeric, NaN, non-positive, fractional dimensions, or values over the caps) returns HTTP 400 with a descriptive error instead of being silently accepted.
- New `capture-viewport.ts` module holds the pure, unit-tested parsing/validation/resolution logic shared by the SDK and the daemon.

```bash
# 2560x1440 CSS pixels at scale 1.5 -> 3840x2160 (4K) backing canvas
curl 'http://127.0.0.1:4099/screenshot?pure=true&width=2560&height=1440&scale=1.5' -o shot.png
```

### 2. Truthful `/healthz` + exit on unexpected browser death (live-fuzz finding)

Killing the Puppeteer browser process used to leave the daemon HTTP server alive with `/healthz` returning `{ok:true}` indefinitely, so PM2 never restarted the wrapper and the reconciler falsely reported healthy.

- `Agent.health()` (new) reports the full chain: browser process alive (`exitCode`/`signalCode` on the child handle), DevTools connection up (`browser.connected`), page open, bridge ready/failed, and best-effort world snapshot readiness (3s timeout, only queried when the transport is alive).
- `GET /healthz` returns 200 `{ok:true, ...detail}` only when everything is live, otherwise 503 with `ok:false` and a `reasons` array (e.g. `"browser process is dead (pid 26725)"`) plus raw `browser`/`page`/`bridge`/`world` state.
- `Agent` listens for Puppeteer `disconnected`; unexpected disconnects (not caused by `close()`/`killBrowserSync()`) are recorded, logged, and fanned out via the new `agent.onUnexpectedDisconnect(cb)`.
- The `voxelize-agent` wrapper wires that callback to a shutdown with exit code 1 so PM2/systemd restart it; signal-driven shutdowns still exit 0, and the `isClosing` guard keeps graceful close from re-triggering the disconnect path (no double-exit loops). `uncaughtException`/`unhandledRejection` now also exit 1 instead of 0.

## Architecture

- **Validation and health evaluation are pure and single-sourced.** `capture-viewport.ts` (syntax via `parseCaptureViewportQuery`, semantics via `resolveCaptureViewport`, typed `CaptureViewportError` mapped to 400) and `health.ts` (`evaluateAgentHealth(input) -> {isHealthy, reasons, ...}`) contain no Puppeteer dependencies, so both are fully unit-testable without a browser; `agent.ts` only gathers raw signals.
- **Capture bounds:** `width`/`height` are integers up to 7680, `scale` up to 4, and the final backing store `width*scale x height*scale` is capped at 8K UHD (7680x4320 = 33,177,600 pixels), since backing pixels are what actually cost memory and encode time. Partial requests fall back to the current viewport, so `?scale=3` alone yields 4K from the 720p default.
- **Resize handshake:** after `page.setViewport`, the agent waits (bounded at 15s, rAF-polled) for a canvas backing store of `floor(width*scale) x floor(height*scale)` (1px tolerance), then double-`requestAnimationFrame`s so a full frame is presented before capture; a timeout downgrades to a warning so pixel-ratio-clamping renderers still capture. The original viewport is restored in a `finally` with the same handshake.
- **Bridge readiness is tracked, not assumed:** `readyPromise` transitions set `isBridgeReady`/`bridgeError`, and `reset()` re-arms the tracking, so `/healthz` is honest during reloads too.
- Why a temporary resize: under software WebGL a 4K frame is ~9x the raster work of 720p; heavy worlds (e.g. Town hub2) already saturate the main thread streaming chunks during join/load, so a permanently large viewport starves the network/chunk pipelines and the agent stalls or disconnects.

## Testing

- 45 vitest unit tests: `capture-viewport.test.ts` (32) for query parsing and range/budget validation, and `health.test.ts` (13) covering the healthy chain, null process handle, disconnected browser, dead process (with/without pid), closed page, bridge not-ready vs failed, unexpected-disconnect reason, snapshot failure/timeout, world not ready, and reason accumulation.
- Live fuzz-scenario reproduction against the real demo server and headless Chrome: with the daemon listening, the browser PID from `/tmp/voxelize-agent-browser-4199.pid` was SIGKILLed; `/healthz` immediately and persistently returned HTTP 503 with `reasons: ["browser disconnected unexpectedly ...", "browser is not connected", "browser process is dead (pid 26725)", "bridge failed: Execution context was destroyed"]` (previously `{ok:true}` forever).
- Real wrapper (`bin/voxelize-agent.ts` via tsx): SIGKILLing its browser produced `browser disconnected unexpectedly` → `shutting down (...)` → exit code 1; a graceful SIGTERM produced `shutting down (SIGTERM)` → exit code 0 with no disconnect noise.
- Coexistence regression on the combined build: baseline screenshot 1280x720, 4K resize 3840x2160, restored 1280x720, invalid query 400.
- Note: this repo's demo client does not install the in-page `window.__agent__` bridge (it lives in the game client), so the healthy 200 path and pure captures cannot be reached in this environment; readiness (`bridge is not ready` → 503) and the full healthy evaluation are covered by unit tests instead.
- `pnpm build`, `pnpm types`, `pnpm test`, and eslint all pass in `packages/agent`.

![Pure temporary-resize 4K capture (3840x2160) of the terrain world](https://cursor.com/artifacts/c/art-b22ea1b0-01e4-47ca-96b2-73477b727830)

<details><summary>Liveness verification log (real SIGKILL runs)</summary>

```
== fuzz scenario: daemon listening, browser SIGKILLed (pid from /tmp/voxelize-agent-browser-4199.pid) ==
-- /healthz now (browser dead for several minutes, daemon still listening) --
{"ok":false,"isHealthy":false,"reasons":["browser disconnected unexpectedly (process died or connection lost)","browser is not connected","browser process is dead (pid 26725)","bridge failed: Execution context was destroyed"],"browser":{"isConnected":false,"isProcessAlive":false,"pid":26725},"page":{"isOpen":true},"bridge":{"isReady":false,"error":"Execution context was destroyed"},"world":{"name":"terrain","isReady":null,"error":null}}
HTTP 503

== wrapper: unexpected browser kill -> nonzero exit ==
[voxelize-agent] browser disconnected unexpectedly (process died or connection lost)
[voxelize-agent] shutting down (browser disconnected unexpectedly (process died or connection lost))...
WRAPPER_EXIT_CODE:1

== wrapper: graceful SIGTERM -> exit 0, no disconnect noise ==
[voxelize-agent] shutting down (SIGTERM)...
WRAPPER_EXIT_CODE:0

== coexistence regression: screenshots on the same build as the liveness fix ==
baseline: HTTP 200 1280x720
4k resize: HTTP 200 3840x2160
restored: HTTP 200 1280x720
invalid:   {"ok":false,"error":"width must be a number, got \"abc\""} [HTTP 400]
```

</details>

<details><summary>Screenshot HTTP verification log</summary>

```
== baseline (no params) ==
HTTP 200
PNG 1280 x 720

== documented 4K example: width=2560&height=1440&scale=1.5 ==
HTTP 200
PNG 3840 x 2160

== viewport restored afterwards ==
HTTP 200
PNG 1280 x 720

== invalid inputs -> 400 ==
?width=abc                         -> {"ok":false,"error":"width must be a number, got \"abc\""} [HTTP 400]
?width=0                           -> {"ok":false,"error":"width must be positive, got 0"} [HTTP 400]
?width=-5                          -> {"ok":false,"error":"width must be positive, got -5"} [HTTP 400]
?width=1280.5                      -> {"ok":false,"error":"width must be an integer number of CSS pixels, got 1280.5"} [HTTP 400]
?height=NaN                        -> {"ok":false,"error":"height must be a number, got \"NaN\""} [HTTP 400]
?scale=0                           -> {"ok":false,"error":"deviceScaleFactor must be positive, got 0"} [HTTP 400]
?scale=99                          -> {"ok":false,"error":"deviceScaleFactor must be at most 4, got 99"} [HTTP 400]
?width=100000                      -> {"ok":false,"error":"width must be at most 7680, got 100000"} [HTTP 400]
?width=7680&height=4320&scale=1.01 -> {"ok":false,"error":"requested capture is 7756x4363 backing pixels (33839428), exceeding the maximum of 33177600 (8K UHD)"} [HTTP 400]
```

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93a12649-ac91-4c4b-9e54-9718f8902a01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93a12649-ac91-4c4b-9e54-9718f8902a01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

