### PR TITLE
fix: zoo join reliability — rejoin chunk resync, view-cone priority, bounded preload, WS ack tolerance

### DIFF
--- a/packages/core/src/core/world/chunk-requests.test.ts
+++ b/packages/core/src/core/world/chunk-requests.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ChunkRequestCandidate,
+  compareChunkRequestPriority,
+} from "./chunk-requests";
+
+const candidate = (
+  cx: number,
+  cz: number,
+  distanceSquared: number,
+  isInView: boolean,
+): ChunkRequestCandidate => ({ cx, cz, distanceSquared, isInView });
+
+describe("compareChunkRequestPriority", () => {
+  it("streams in-view chunks before out-of-view chunks regardless of distance", () => {
+    const farInView = candidate(8, 0, 64, true);
+    const nearOutOfView = candidate(-1, 0, 1, false);
+
+    expect(compareChunkRequestPriority(farInView, nearOutOfView)).toBeLessThan(
+      0,
+    );
+    expect(
+      compareChunkRequestPriority(nearOutOfView, farInView),
+    ).toBeGreaterThan(0);
+  });
+
+  it("orders chunks within the same view group by distance", () => {
+    const near = candidate(1, 0, 1, true);
+    const far = candidate(4, 0, 16, true);
+
+    expect(compareChunkRequestPriority(near, far)).toBeLessThan(0);
+    expect(compareChunkRequestPriority(far, near)).toBeGreaterThan(0);
+  });
+
+  it("keeps out-of-view chunks in the sorted result instead of dropping them", () => {
+    const candidates = [
+      candidate(-2, 0, 4, false),
+      candidate(3, 0, 9, true),
+      candidate(-1, 0, 1, false),
+      candidate(1, 0, 1, true),
+    ];
+
+    const sorted = [...candidates].sort(compareChunkRequestPriority);
+
+    expect(sorted.map(({ cx }) => cx)).toEqual([1, 3, -1, -2]);
+    expect(sorted).toHaveLength(candidates.length);
+  });
+});

--- a/packages/core/src/core/world/chunk-requests.ts
+++ b/packages/core/src/core/world/chunk-requests.ts
@@ -1,0 +1,17 @@
+export type ChunkRequestCandidate = {
+  cx: number;
+  cz: number;
+  distanceSquared: number;
+  isInView: boolean;
+};
+
+export function compareChunkRequestPriority(
+  a: ChunkRequestCandidate,
+  b: ChunkRequestCandidate,
+): number {
+  if (a.isInView !== b.isInView) {
+    return a.isInView ? -1 : 1;
+  }
+
+  return a.distanceSquared - b.distanceSquared;
+}

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -509,7 +509,7 @@ const defaultOptions: WorldClientOptions = {
   maxUrgentMeshWorkers: 4,
   clientOnlyMeshing: true,
   minLightLevel: 0.04,
-  chunkRerequestInterval: 10000,
+  chunkRerequestInterval: 300,
   defaultRenderRadius: 6,
   fogNearRenderRatio: 0.45,
   fogFarRenderRatio: 0.78,

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -135,6 +135,10 @@ import {
 } from "./block";
 import { Chunk } from "./chunk";
 import { ChunkRenderer, makeSceneColorTexture } from "./chunk-renderer";
+import {
+  ChunkRequestCandidate,
+  compareChunkRequestPriority,
+} from "./chunk-requests";
 import { Clouds, CloudsOptions } from "./clouds";
 import { CSMRenderer } from "./csm-renderer";
 import { ItemDef, ItemRegistry } from "./items";
@@ -153,6 +157,7 @@ import MeshWorker from "./workers/mesh-worker.ts?worker";
 export * from "./block";
 export * from "./chunk";
 export * from "./chunk-renderer";
+export * from "./chunk-requests";
 export * from "./clouds";
 export * from "./csm-renderer";
 export * from "./entity-shadow-uniforms";
@@ -925,8 +930,9 @@ export class World<T = any> extends Scene implements NetIntercept {
   private initialData: any = null;
   private initialEntities: any = null;
 
-  // Loaded chunks whose server-side interest must be re-established after a
-  // rejoin, drained through the paced chunk-request flow.
+  // Chunks with local data (processing or loaded) whose server-side interest
+  // must be re-established after a rejoin, drained through the paced
+  // chunk-request flow.
   private chunkRefreshQueue = new Set<string>();
 
   public extraInitData: Record<string, unknown> = {};
@@ -3861,11 +3867,12 @@ export class World<T = any> extends Scene implements NetIntercept {
 
         // An INIT on an already-initialized world is a rejoin after a
         // reconnect. The server process behind it may be brand new, holding
-        // none of the chunks this client renders, so ask for all of them
-        // again: chunk interests get re-registered (entities inside resume
-        // simulating) and any terrain that changed re-streams.
+        // none of the chunks this client renders, so resync every chunk
+        // stage: loaded/processing chunks re-register interest (entities
+        // inside resume simulating) and in-flight requests are reissued
+        // immediately instead of idling until the rerequest interval.
         if (this.isInitialized) {
-          this.requestLoadedChunksRefresh();
+          this.resyncChunkStagesAfterRejoin();
         }
 
         break;
@@ -4058,11 +4065,11 @@ export class World<T = any> extends Scene implements NetIntercept {
     return this._deleteRadius;
   }
 
-  private requestLoadedChunksRefresh() {
+  private resyncChunkStagesAfterRejoin() {
     this.chunkRefreshQueue.clear();
-    this.chunkPipeline.forEachLoaded((_, name) => {
+    for (const name of this.chunkPipeline.resyncForRejoin()) {
       this.chunkRefreshQueue.add(name);
-    });
+    }
   }
 
   private requestChunks(center: Coords2, direction: Vector3) {
@@ -4087,13 +4094,14 @@ export class World<T = any> extends Scene implements NetIntercept {
         : Math.max(ratio ** chunkLoadExponent, 0.1);
 
     const [centerX, centerZ] = center;
-    const toRequestSet = new Set<string>();
+    const candidates: ChunkRequestCandidate[] = [];
 
     const renderRadiusSquared = renderRadius * renderRadius;
 
     for (let ox = -renderRadius; ox <= renderRadius; ox++) {
       for (let oz = -renderRadius; oz <= renderRadius; oz++) {
-        if (ox * ox + oz * oz > renderRadiusSquared) continue;
+        const distanceSquared = ox * ox + oz * oz;
+        if (distanceSquared > renderRadiusSquared) continue;
 
         const cx = centerX + ox;
         const cz = centerZ + oz;
@@ -4102,72 +4110,51 @@ export class World<T = any> extends Scene implements NetIntercept {
           continue;
         }
 
-        if (
-          hasDirection &&
-          !this.isChunkInView(center, [cx, cz], direction, angleThreshold)
-        ) {
-          continue;
-        }
-
         const chunkName = ChunkUtils.getChunkName([cx, cz]);
 
         const stage = this.chunkPipeline.getStage(chunkName);
 
-        if (stage === "loaded") {
+        if (stage === "loaded" || stage === "processing") {
           continue;
         }
 
         if (stage === "requested") {
           const retryCount = this.chunkPipeline.incrementRetry(chunkName);
 
-          if (retryCount > chunkRerequestInterval) {
-            this.chunkPipeline.remove(chunkName);
-            toRequestSet.add(`${cx},${cz}`);
+          if (retryCount <= chunkRerequestInterval) {
+            continue;
           }
 
-          continue;
+          // The request is considered lost; drop the stage so the chunk is
+          // reissued below.
+          this.chunkPipeline.remove(chunkName);
         }
 
-        if (stage === "processing") {
-          continue;
-        }
+        // The view cone is a priority, not a filter: in-view chunks stream
+        // first, but out-of-view chunks still consume any leftover budget.
+        const isInView =
+          !hasDirection ||
+          this.isChunkInView(center, [cx, cz], direction, angleThreshold);
 
-        toRequestSet.add(`${cx},${cz}`);
+        candidates.push({ cx, cz, distanceSquared, isInView });
       }
     }
 
-    // i guess we still want to update the direction/center?
-    // if (toRequestSet.size === 0) {
-    //   return;
-    // }
+    candidates.sort(compareChunkRequestPriority);
 
-    const toRequestArray = Array.from(toRequestSet).map((coords) =>
-      coords.split(",").map(Number),
-    );
-
-    // Sort the chunks by distance from the center, closest first.
-    toRequestArray.sort((a, b) => {
-      const ad = (a[0] - center[0]) ** 2 + (a[1] - center[1]) ** 2;
-      const bd = (b[0] - center[0]) ** 2 + (b[1] - center[1]) ** 2;
-      return ad - bd;
-    });
-
-    // LOD:
-    // < 4 chunks: 0
-    // > 4 < 6 chunks: 1
-    // > 6 chunks: 2
-
-    const toRequest = toRequestArray.slice(0, maxChunkRequestsPerUpdate);
+    const toRequest = candidates
+      .slice(0, maxChunkRequestsPerUpdate)
+      .map(({ cx, cz }) => [cx, cz]);
 
     // Drain rejoin refreshes with the same per-update budget. These chunks
-    // stay loaded and renderable; the request only re-registers server-side
+    // keep their local data; the request only re-registers server-side
     // interest and pulls fresh data for them.
     const refreshBatch: number[][] = [];
     let refreshBudget = maxChunkRequestsPerUpdate - toRequest.length;
     for (const name of this.chunkRefreshQueue) {
       if (refreshBudget <= 0) break;
       this.chunkRefreshQueue.delete(name);
-      if (!this.chunkPipeline.getLoadedChunk(name)) continue;
+      if (!this.chunkPipeline.getStage(name)) continue;
       refreshBatch.push(ChunkUtils.parseChunkName(name) as number[]);
       refreshBudget -= 1;
     }

--- a/packages/core/src/core/world/pipelines.test.ts
+++ b/packages/core/src/core/world/pipelines.test.ts
@@ -1,0 +1,74 @@
+import { ChunkProtocol } from "@voxelize/protocol";
+import { describe, expect, it } from "vitest";
+
+import { Coords2 } from "../../types";
+import { ChunkUtils } from "../../utils";
+
+import { Chunk } from "./chunk";
+import { ChunkPipeline } from "./pipelines";
+
+const options = {
+  size: 2,
+  maxHeight: 2,
+  maxLightLevel: 15,
+  subChunks: 1,
+};
+
+const makeChunk = (coords: Coords2) =>
+  new Chunk(ChunkUtils.getChunkName(coords), coords, options);
+
+const protocolFor = (coords: Coords2): ChunkProtocol => ({
+  id: ChunkUtils.getChunkName(coords),
+  x: coords[0],
+  z: coords[1],
+  meshes: [],
+  voxels: new Uint32Array(),
+  lights: new Uint32Array(),
+});
+
+describe("ChunkPipeline.resyncForRejoin", () => {
+  it("drops requested chunks so they are reissued immediately", () => {
+    const pipeline = new ChunkPipeline();
+    pipeline.markRequested([0, 0]);
+    pipeline.markRequested([1, 0]);
+
+    pipeline.resyncForRejoin();
+
+    expect(pipeline.getStage(ChunkUtils.getChunkName([0, 0]))).toBeNull();
+    expect(pipeline.getStage(ChunkUtils.getChunkName([1, 0]))).toBeNull();
+    expect(pipeline.requestedCount).toBe(0);
+  });
+
+  it("returns processing and loaded chunks for interest re-registration", () => {
+    const pipeline = new ChunkPipeline();
+    pipeline.markRequested([0, 0]);
+    pipeline.markProcessing([1, 0], "load", protocolFor([1, 0]));
+    pipeline.markLoaded([2, 0], makeChunk([2, 0]));
+
+    const toRefresh = pipeline.resyncForRejoin();
+
+    expect(toRefresh).toEqual(
+      expect.arrayContaining([
+        ChunkUtils.getChunkName([1, 0]),
+        ChunkUtils.getChunkName([2, 0]),
+      ]),
+    );
+    expect(toRefresh).toHaveLength(2);
+  });
+
+  it("keeps local data for processing and loaded chunks", () => {
+    const pipeline = new ChunkPipeline();
+    const loaded = makeChunk([2, 0]);
+    pipeline.markProcessing([1, 0], "load", protocolFor([1, 0]));
+    pipeline.markLoaded([2, 0], loaded);
+
+    pipeline.resyncForRejoin();
+
+    expect(
+      pipeline.getProcessingData(ChunkUtils.getChunkName([1, 0]))?.data.x,
+    ).toBe(1);
+    expect(pipeline.getLoadedChunk(ChunkUtils.getChunkName([2, 0]))).toBe(
+      loaded,
+    );
+  });
+});

--- a/packages/core/src/core/world/pipelines.ts
+++ b/packages/core/src/core/world/pipelines.ts
@@ -129,6 +129,18 @@ export class ChunkPipeline {
     return chunk;
   }
 
+  resyncForRejoin(): string[] {
+    // Requested chunks have no local data and the new server process holds
+    // no interest for them: drop them so they are reissued as fresh requests.
+    for (const name of [...this.indices.requested]) {
+      this.removeStage(name);
+    }
+
+    // Processing and loaded chunks keep their local data; the caller
+    // re-requests them to re-register server-side interest.
+    return [...this.indices.processing, ...this.indices.loaded];
+  }
+
   forEach(stage: StageType, callback: (name: string) => void): void {
     this.indices[stage].forEach(callback);
   }

--- a/server/lib.rs
+++ b/server/lib.rs
@@ -36,7 +36,16 @@ pub use world::*;
 
 pub type RtcSenders = Arc<Mutex<HashMap<String, mpsc::UnboundedSender<Vec<u8>>>>>;
 
-const CLIENT_MESSAGE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(1);
+/// How long to wait for the server actor to ack a client message before
+/// logging that the ack is slow. A slow ack (e.g. the actor is busy ticking
+/// or preloading) is not fatal: the session keeps waiting, which naturally
+/// backpressures further reads from this socket.
+const CLIENT_MESSAGE_SLOW_ACK_WARN_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Hard upper bound on waiting for a client message ack. Only a server actor
+/// that is truly wedged should ever hit this; the session is then dropped so
+/// its resources can be reclaimed.
+const CLIENT_MESSAGE_ACK_HARD_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How often the server pings each WebSocket connection.
 const DEFAULT_WS_HEARTBEAT_INTERVAL_MS: u64 = 10_000;
@@ -226,18 +235,42 @@ async fn handle_ws_connection(
                             }
                         };
 
-                        match tokio::time::timeout(
-                            CLIENT_MESSAGE_RESPONSE_TIMEOUT,
-                            server.send(ClientMessage::new(
-                                session_id.clone(),
-                                message,
-                                wire_bytes,
-                                Some(connection_token.clone()),
-                            )),
-                        )
-                        .await
-                        {
-                            Ok(Ok(Some(error_msg))) => {
+                        // Await the ack to the same in-flight send: a slow ack
+                        // must not drop the session, and no further frames are
+                        // read from this socket while waiting, which preserves
+                        // ordering and backpressure without busy-looping.
+                        let send_future = server.send(ClientMessage::new(
+                            session_id.clone(),
+                            message,
+                            wire_bytes,
+                            Some(connection_token.clone()),
+                        ));
+                        tokio::pin!(send_future);
+
+                        let started_waiting = std::time::Instant::now();
+                        let ack = loop {
+                            match tokio::time::timeout(
+                                CLIENT_MESSAGE_SLOW_ACK_WARN_INTERVAL,
+                                &mut send_future,
+                            )
+                            .await
+                            {
+                                Ok(result) => break Some(result),
+                                Err(_) => {
+                                    let waited = started_waiting.elapsed();
+                                    if waited >= CLIENT_MESSAGE_ACK_HARD_TIMEOUT {
+                                        break None;
+                                    }
+                                    warn!(
+                                        "[WS] ClientMessage ack slow ({:?}) for {}; still waiting",
+                                        waited, session_id
+                                    );
+                                }
+                            }
+                        };
+
+                        match ack {
+                            Some(Ok(Some(error_msg))) => {
                                 warn!("[WS] ClientMessage error: {}", error_msg);
                                 let error_response = encode_message(
                                     &Message::new(&MessageType::Error).text(&error_msg).build(),
@@ -245,13 +278,16 @@ async fn handle_ws_connection(
                                 let _ = session.binary(error_response).await;
                                 break;
                             }
-                            Ok(Ok(None)) => {}
-                            Ok(Err(e)) => {
+                            Some(Ok(None)) => {}
+                            Some(Err(e)) => {
                                 warn!("[WS] Actor mailbox error: {:?}", e);
                                 break;
                             }
-                            Err(_) => {
-                                warn!("[WS] ClientMessage timed out");
+                            None => {
+                                warn!(
+                                    "[WS] ClientMessage ack exceeded {:?} for {}; dropping connection",
+                                    CLIENT_MESSAGE_ACK_HARD_TIMEOUT, session_id
+                                );
                                 break;
                             }
                         }

--- a/server/server/mod.rs
+++ b/server/server/mod.rs
@@ -1733,3 +1733,53 @@ mod lifecycle_tests {
         });
     }
 }
+
+/// Preload completion against a real `SyncWorld` actor: the completion check
+/// must only count in-bounds chunks, so a preload radius larger than the
+/// world bounds still finishes instead of leaving `preloading` true forever.
+#[cfg(test)]
+mod preload_tests {
+    use super::*;
+    use crate::FlatlandStage;
+
+    #[test]
+    fn bounded_world_preload_completes_with_oversize_radius() {
+        actix::System::new().block_on(async {
+            let mut server = Server::new().debug(false).build();
+
+            // A 3x3-chunk world with a preload radius far beyond its bounds:
+            // most cells of the completion check square can never be ready.
+            let config = WorldConfig::new()
+                .min_chunk([-1, -1])
+                .max_chunk([1, 1])
+                .preload(true)
+                .preload_radius(5)
+                .build();
+
+            let mut bounded = World::new("bounded", &config);
+            bounded.pipeline_mut().add_stage(FlatlandStage::new());
+
+            let world = server
+                .add_world(bounded)
+                .expect("world should register")
+                .clone();
+
+            world.send(Preload).await.expect("preload should schedule");
+
+            let mut preloading = true;
+            for _ in 0..2000 {
+                world.send(Tick).await.expect("tick should run");
+                let info = world.send(GetInfo).await.expect("info should be readable");
+                if !info.preloading {
+                    preloading = false;
+                    break;
+                }
+            }
+
+            assert!(
+                !preloading,
+                "bounded world preload must complete even when the preload radius exceeds the world bounds"
+            );
+        });
+    }
+}

--- a/server/world/mod.rs
+++ b/server/world/mod.rs
@@ -1877,15 +1877,25 @@ impl World {
             let light_padding = (self.config().max_light_level as f32
                 / self.config().chunk_size as f32)
                 .ceil() as usize;
-            let check_radius = (self.config().preload_radius - light_padding) as i32;
+            let check_radius = self.config().preload_radius.saturating_sub(light_padding) as i32;
 
+            // Only in-bounds chunks are scheduled by `preload`, so only they
+            // can ever become ready: counting out-of-bounds cells toward the
+            // expected total would leave `preloading` true forever on bounded
+            // worlds whose preload radius exceeds the world bounds.
             let mut total = 0;
-            let supposed = (check_radius * 2).pow(2);
+            let mut supposed = 0;
 
             for x in -check_radius..=check_radius {
                 for z in -check_radius..=check_radius {
                     let chunks = self.chunks();
                     let coords = Vec2(x, z);
+
+                    if !chunks.is_within_world(&coords) {
+                        continue;
+                    }
+
+                    supposed += 1;
 
                     if chunks.is_chunk_ready(&coords) {
                         total += 1;
@@ -1903,7 +1913,11 @@ impl World {
                 }
             }
 
-            self.preload_progress = (total as f32 / supposed as f32).min(1.0);
+            self.preload_progress = if supposed == 0 {
+                1.0
+            } else {
+                (total as f32 / supposed as f32).min(1.0)
+            };
 
             if total >= supposed {
                 self.preloading = false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Engine-side changes backing Town's zoo join reliability work (shaoruu/town#86). The Town repo was not accessible from this environment, so each behavior was independently root-caused against current voxelize main rather than ported from the exported patches.

## Root causes and behavior

### Rejoin/INIT left in-flight chunk requests stranded
On a rejoin INIT the new server process holds no chunk interest for the client. The client only re-requested loaded chunks; chunks in the `requested` stage sat idle until the rerequest interval expired, and `processing` chunks never re-registered interest. `ChunkPipeline.resyncForRejoin` now drops `requested` stages so those chunks are reissued immediately, and returns `processing` + `loaded` chunks for the paced refresh queue (local data is kept; the request only re-registers interest and pulls fresh terrain).

### Lost-chunk rerequest interval was ~33x the documented value
`chunkRerequestInterval` is documented as 300 updates but defaulted to 10000, so a lost request idled roughly three minutes at 60fps. Default corrected to 300.

### View cone was a permanent filter, not a priority
`requestChunks` skipped any chunk outside the view cone, so chunks behind the camera never streamed (and their lost-request retries never ticked). All in-radius chunks are now candidates sorted in-view first, then by distance, with the existing `maxChunkRequestsPerUpdate` budget applied to the sorted list: in-view chunks win the budget, out-of-view chunks fill the remainder.

### Bounded worlds could preload forever
Preload scheduling filters chunks through `is_within_world`, but the completion check in `World::tick` iterated the full check square and expected `(2R)^2` ready chunks. On a world whose bounds are smaller than the preload radius, out-of-bounds cells can never become ready, so `preloading` stayed `true` forever (blocking `/health` readiness). The completion check now skips out-of-bounds coords and derives the expected total from the in-bounds cells it actually iterates (which also fixes the `(2R)^2` vs `(2R+1)^2` undercount). The `preload_radius - light_padding` subtraction now saturates instead of underflowing.

### A slow ClientMessage ack dropped the whole WS session
An ack that took over one second tore down the socket, so a server actor busy ticking or preloading disconnected healthy clients. The session now keeps awaiting the same in-flight send (logging each second) with a 30s hard cap for a truly wedged actor.

## Performance implications
- `requestChunks` builds one candidate array per update, bounded by the render-radius disc (a few hundred entries), replacing the previous per-chunk string set plus split/parse round-trip; one sort per update as before.
- The WS ack path reads no further frames while an ack is pending, so ordering and inbound backpressure are preserved with no busy loop; outbound lanes are untouched.
- Preload completion adds one `is_within_world` bounds check per cell per tick while preloading only.

## Compatibility
- No wire-format changes; LOAD/UNLOAD/INIT protocol unchanged.
- Unbounded worlds see an identical preload result (every cell is in bounds).
- Fully-loaded steady state is unchanged for the view-cone change; it only affects which pending chunks are requested first.

## Verification
- `pnpm --filter @voxelize/core test` — 46 tests pass, including new suites for `ChunkPipeline.resyncForRejoin` (requested dropped, processing/loaded returned with data kept) and `compareChunkRequestPriority` (in-view first, distance within groups, out-of-view retained).
- `cargo test --lib` — 46 tests pass, including a new actor-level regression test: a 3x3-chunk bounded world with preload radius 5 must finish preloading. Verified the test fails on main's completion check and passes with the fix.
- `cargo check` and `pnpm test:rust` (mesher + lights) pass; `tsc --noEmit` on @voxelize/core reports no errors in changed files; eslint clean on changed files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c64fd27-8261-46f7-969c-2b5197173c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c64fd27-8261-46f7-969c-2b5197173c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

