### PR TITLE
perf(server): budget per-client entity state flushes to fix unbounded entity broadcast pressure

### DIFF
--- a/server/world/components/metadata.rs
+++ b/server/world/components/metadata.rs
@@ -88,3 +88,51 @@ impl MetadataComp {
         self.map.clear();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unchanged_metadata_reports_no_update() {
+        let mut metadata = MetadataComp::new();
+        metadata.set_value("position", json!([1.0, 2.0, 3.0]));
+
+        let (first, updated) = metadata.to_cached_str();
+        assert!(updated);
+
+        // Rewriting the same value every tick (as the metadata systems do)
+        // must not report a change.
+        for _ in 0..10 {
+            metadata.set_value("position", json!([1.0, 2.0, 3.0]));
+            let (json_str, updated) = metadata.to_cached_str();
+            assert!(!updated);
+            assert_eq!(json_str, first);
+        }
+    }
+
+    #[test]
+    fn changed_metadata_reports_an_update_once() {
+        let mut metadata = MetadataComp::new();
+        metadata.set_value("position", json!([1.0, 2.0, 3.0]));
+        metadata.to_cached_str();
+
+        metadata.set_value("position", json!([4.0, 5.0, 6.0]));
+        let (_, updated) = metadata.to_cached_str();
+        assert!(updated);
+
+        let (_, updated) = metadata.to_cached_str();
+        assert!(!updated);
+    }
+
+    #[test]
+    fn mark_dirty_forces_a_reemit() {
+        let mut metadata = MetadataComp::new();
+        metadata.set_value("position", json!([1.0, 2.0, 3.0]));
+        metadata.to_cached_str();
+
+        metadata.mark_dirty();
+        let (_, updated) = metadata.to_cached_str();
+        assert!(updated);
+    }
+}

--- a/server/world/config.rs
+++ b/server/world/config.rs
@@ -127,6 +127,20 @@ pub struct WorldConfig {
     /// not changed, letting clients treat prolonged silence as a lost entity.
     pub entity_keep_alive_interval: u64,
 
+    /// Maximum entity UPDATEs flushed to one client per tick. Pending updates
+    /// beyond the budget stay staged (coalescing to their newest value) and
+    /// flush on subsequent ticks, oldest-staged first and nearest first within
+    /// the same age. Keep `budget x client staleness window` comfortably above
+    /// the interest set size so a slow rotation can never starve an entity
+    /// past the client's staleness timeout.
+    pub max_entity_updates_per_tick: usize,
+
+    /// Maximum metadata bytes of entity UPDATEs flushed to one client per
+    /// tick. Bounds outbound bandwidth per client when many tracked entities
+    /// change at once; at least one update is always flushed so the rotation
+    /// makes progress even when a single update exceeds the budget.
+    pub max_entity_update_bytes_per_tick: usize,
+
     /// Radius in blocks within which another player's (peer's) state
     /// replicates to a client. `None` (default) replicates every peer to every
     /// client, matching historical behavior. Unlike entities, peers have no
@@ -187,6 +201,8 @@ const DEFAULT_ALLOW_CLIENT_VOXEL_WRITES: bool = false;
 const DEFAULT_ENTITY_VISIBLE_RADIUS_CHUNKS: f32 = 24.0;
 const DEFAULT_ENTITY_RELEASE_RADIUS_RATIO: f32 = 1.125;
 const DEFAULT_ENTITY_KEEP_ALIVE_INTERVAL: u64 = 60;
+const DEFAULT_MAX_ENTITY_UPDATES_PER_TICK: usize = 64;
+const DEFAULT_MAX_ENTITY_UPDATE_BYTES_PER_TICK: usize = 24 * 1024;
 
 /// Builder for a world configuration.
 pub struct WorldConfigBuilder {
@@ -227,6 +243,8 @@ pub struct WorldConfigBuilder {
     entity_visible_radius: f32,
     entity_release_radius: f32,
     entity_keep_alive_interval: u64,
+    max_entity_updates_per_tick: usize,
+    max_entity_update_bytes_per_tick: usize,
     peer_visible_radius: Option<f32>,
 }
 
@@ -271,6 +289,8 @@ impl WorldConfigBuilder {
             entity_visible_radius: 0.0,
             entity_release_radius: 0.0,
             entity_keep_alive_interval: DEFAULT_ENTITY_KEEP_ALIVE_INTERVAL,
+            max_entity_updates_per_tick: DEFAULT_MAX_ENTITY_UPDATES_PER_TICK,
+            max_entity_update_bytes_per_tick: DEFAULT_MAX_ENTITY_UPDATE_BYTES_PER_TICK,
             peer_visible_radius: None,
         }
     }
@@ -472,6 +492,22 @@ impl WorldConfigBuilder {
         self
     }
 
+    /// Maximum entity UPDATEs flushed to one client per tick. Must be positive.
+    pub fn max_entity_updates_per_tick(mut self, max_entity_updates_per_tick: usize) -> Self {
+        self.max_entity_updates_per_tick = max_entity_updates_per_tick;
+        self
+    }
+
+    /// Maximum metadata bytes of entity UPDATEs flushed to one client per
+    /// tick. Must be positive.
+    pub fn max_entity_update_bytes_per_tick(
+        mut self,
+        max_entity_update_bytes_per_tick: usize,
+    ) -> Self {
+        self.max_entity_update_bytes_per_tick = max_entity_update_bytes_per_tick;
+        self
+    }
+
     /// Optional radius (in blocks) limiting which peers replicate to a client.
     /// `None` (default) replicates all peers to all clients.
     pub fn peer_visible_radius(mut self, peer_visible_radius: Option<f32>) -> Self {
@@ -513,6 +549,14 @@ impl WorldConfigBuilder {
             if peer_visible_radius <= 0.0 {
                 panic!("Peer visible radius must be positive (or None for unlimited).");
             }
+        }
+
+        if self.max_entity_updates_per_tick == 0 {
+            panic!("Max entity updates per tick must be positive.");
+        }
+
+        if self.max_entity_update_bytes_per_tick == 0 {
+            panic!("Max entity update bytes per tick must be positive.");
         }
 
         WorldConfig {
@@ -567,6 +611,8 @@ impl WorldConfigBuilder {
             entity_visible_radius,
             entity_release_radius,
             entity_keep_alive_interval: self.entity_keep_alive_interval,
+            max_entity_updates_per_tick: self.max_entity_updates_per_tick,
+            max_entity_update_bytes_per_tick: self.max_entity_update_bytes_per_tick,
             peer_visible_radius: self.peer_visible_radius,
         }
     }

--- a/server/world/config.rs
+++ b/server/world/config.rs
@@ -129,16 +129,21 @@ pub struct WorldConfig {
 
     /// Maximum entity UPDATEs flushed to one client per tick. Pending updates
     /// beyond the budget stay staged (coalescing to their newest value) and
-    /// flush on subsequent ticks, oldest-staged first and nearest first within
-    /// the same age. Keep `budget x client staleness window` comfortably above
-    /// the interest set size so a slow rotation can never starve an entity
-    /// past the client's staleness timeout.
+    /// flush on subsequent ticks, oldest-staged first and nearest first
+    /// within the same age — so the rotation is starvation-free, but the
+    /// revisit latency depends on both this cap and the payload-byte cap
+    /// relative to actual payload sizes. Size the two budgets so a full
+    /// rotation of the expected interest set completes comfortably inside
+    /// the client's staleness timeout.
     pub max_entity_updates_per_tick: usize,
 
-    /// Maximum metadata bytes of entity UPDATEs flushed to one client per
-    /// tick. Bounds outbound bandwidth per client when many tracked entities
+    /// Approximate per-tick entity-state payload budget per client: the
+    /// summed id + type + metadata string bytes of UPDATEs in one flush, not
+    /// the encoded protobuf frame size (protobuf/frame overhead can exceed
+    /// it). Bounds outbound bandwidth per client when many tracked entities
     /// change at once; at least one update is always flushed so the rotation
-    /// makes progress even when a single update exceeds the budget.
+    /// makes progress even when a single update exceeds the budget. Measure
+    /// actual frame sizes with the `entity_batch_send.byteSize` perf field.
     pub max_entity_update_bytes_per_tick: usize,
 
     /// Radius in blocks within which another player's (peer's) state
@@ -498,8 +503,9 @@ impl WorldConfigBuilder {
         self
     }
 
-    /// Maximum metadata bytes of entity UPDATEs flushed to one client per
-    /// tick. Must be positive.
+    /// Approximate entity-state payload budget (id + type + metadata string
+    /// bytes, not encoded frame bytes) flushed to one client per tick. Must
+    /// be positive.
     pub fn max_entity_update_bytes_per_tick(
         mut self,
         max_entity_update_bytes_per_tick: usize,

--- a/server/world/replication/mod.rs
+++ b/server/world/replication/mod.rs
@@ -34,7 +34,12 @@
 //! - staging a newer value **overwrites** the pending one — never appends;
 //! - the structure is **bounded** by (clients x items in interest), and a hard
 //!   per-client cap backstops that bound;
-//! - flushing ships the current snapshot and leaves nothing behind;
+//! - flushing is **budgeted** per client per tick ([`EntityFlushBudget`]):
+//!   when more entity slots are pending than the budget allows, the oldest
+//!   staged slots flush first (nearest first within the same age) and the
+//!   rest stay pending — still coalescing — for subsequent ticks. This bounds
+//!   the bytes a single tick can put on one client's socket, no matter how
+//!   many tracked entities changed at once;
 //! - when a client's socket is backed up, flushing is **skipped** for that
 //!   client while its slots keep coalescing, so the moment the socket drains
 //!   it receives one current snapshot instead of a replay of stale frames.
@@ -83,12 +88,52 @@ pub const MAX_PENDING_INBOUND_PER_CLIENT: usize = 64;
 /// How many perf trace ids a client's slot set remembers between flushes.
 const MAX_PENDING_TRACE_IDS: usize = 8;
 
+/// Per-tick, per-client flush budget for entity state. Both limits bound one
+/// flush; at least one update is always shipped so the rotation makes
+/// progress even when a single update exceeds `max_bytes`.
+#[derive(Debug, Clone, Copy)]
+pub struct EntityFlushBudget {
+    /// Maximum entity UPDATEs in one flush.
+    pub max_updates: usize,
+    /// Maximum summed wire cost (id + type + metadata bytes) in one flush.
+    pub max_bytes: usize,
+}
+
+impl EntityFlushBudget {
+    /// A budget that never bites: every pending slot drains each flush.
+    pub const UNLIMITED: Self = Self {
+        max_updates: usize::MAX,
+        max_bytes: usize::MAX,
+    };
+}
+
+/// One pending entity UPDATE for one client, with the ordering facts the
+/// budgeted flush needs: how long the slot has been waiting and how close the
+/// entity is to the client.
+struct EntitySlot {
+    update: EntityProtocol,
+    /// Squared distance from the client at the newest staging.
+    distance_sq: f32,
+    /// Tick at which this slot became pending (preserved across overwrites,
+    /// reset on flush), so a slot that keeps coalescing still ages and can
+    /// never be starved by newer, nearer traffic.
+    staged_tick: u64,
+}
+
+impl EntitySlot {
+    fn wire_cost(&self) -> usize {
+        self.update.id.len()
+            + self.update.r#type.len()
+            + self.update.metadata.as_ref().map_or(0, String::len)
+    }
+}
+
 /// Latest-wins slots for one client. One slot per replicated item; staging a
 /// newer value overwrites the pending one in place.
 #[derive(Default)]
 struct ClientStateSlots {
     /// entity id -> newest pending entity UPDATE for this client.
-    entities: HashMap<String, EntityProtocol>,
+    entities: HashMap<String, EntitySlot>,
     /// peer id -> newest pending peer snapshot for this client.
     peers: HashMap<String, PeerProtocol>,
     /// Perf trace ids of the staging batches coalesced into these slots.
@@ -141,21 +186,41 @@ impl ReplicatedStateBuffer {
     /// events, not state: route them through [`crate::MessageQueues`] and call
     /// [`Self::clear_entity`] so a stale pending update cannot be flushed
     /// after the transition and resurrect a released entity.
-    pub fn stage_entity_update(&mut self, client_id: &str, update: EntityProtocol) {
+    ///
+    /// `distance_sq` is the squared client-to-entity distance and `tick` is
+    /// the staging tick; together they order the budgeted flush (oldest slot
+    /// first, nearest first within the same age). An overwrite refreshes the
+    /// distance but keeps the slot's original staging tick, so coalescing
+    /// never resets a slot's place in the rotation.
+    pub fn stage_entity_update(
+        &mut self,
+        client_id: &str,
+        update: EntityProtocol,
+        distance_sq: f32,
+        tick: u64,
+    ) {
         let slots = self.clients.entry(client_id.to_owned()).or_default();
         match slots.entities.get_mut(&update.id) {
             Some(pending) => {
-                if update.metadata.is_none() && pending.metadata.is_some() {
+                if update.metadata.is_none() && pending.update.metadata.is_some() {
                     return;
                 }
-                *pending = update;
+                pending.update = update;
+                pending.distance_sq = distance_sq;
             }
             None => {
                 if slots.len() >= MAX_STATE_SLOTS_PER_CLIENT {
                     self.dropped_updates += 1;
                     return;
                 }
-                slots.entities.insert(update.id.clone(), update);
+                slots.entities.insert(
+                    update.id.clone(),
+                    EntitySlot {
+                        update,
+                        distance_sq,
+                        staged_tick: tick,
+                    },
+                );
             }
         }
     }
@@ -215,18 +280,83 @@ impl ReplicatedStateBuffer {
             .unwrap_or(false)
     }
 
-    /// Take the client's current snapshot for sending, leaving its slots
-    /// empty. Returns `None` when there is nothing pending.
-    pub fn drain_client(&mut self, client_id: &str) -> Option<ClientStateFlush> {
+    /// Take the client's pending state for sending, up to `budget` entity
+    /// updates/bytes. Entity slots beyond the budget stay pending (and keep
+    /// coalescing); selection is deterministic — oldest staged tick first,
+    /// nearest first within the same tick, entity id as the final tiebreak —
+    /// so every pending slot flushes within `pending / max_updates` ticks and
+    /// no entity can be starved. Peer snapshots are few and latency-critical,
+    /// so they always flush in full. Returns `None` when nothing is pending.
+    pub fn drain_client(
+        &mut self,
+        client_id: &str,
+        budget: EntityFlushBudget,
+    ) -> Option<ClientStateFlush> {
         let slots = self.clients.get_mut(client_id)?;
         if slots.is_empty() {
             return None;
         }
+
+        let within_budget = slots.entities.len() <= budget.max_updates
+            && slots
+                .entities
+                .values()
+                .map(EntitySlot::wire_cost)
+                .sum::<usize>()
+                <= budget.max_bytes;
+
+        let entities: Vec<EntityProtocol> = if within_budget {
+            slots
+                .entities
+                .drain()
+                .map(|(_, slot)| slot.update)
+                .collect()
+        } else {
+            let mut order: Vec<(u64, f32, &String)> = slots
+                .entities
+                .iter()
+                .map(|(id, slot)| (slot.staged_tick, slot.distance_sq, id))
+                .collect();
+            order.sort_unstable_by(|left, right| {
+                left.0
+                    .cmp(&right.0)
+                    .then_with(|| left.1.total_cmp(&right.1))
+                    .then_with(|| left.2.cmp(right.2))
+            });
+
+            let mut selected: Vec<String> = Vec::new();
+            let mut bytes = 0;
+            for (_, _, id) in order {
+                if selected.len() >= budget.max_updates {
+                    break;
+                }
+                let cost = slots.entities[id].wire_cost();
+                if !selected.is_empty() && bytes + cost > budget.max_bytes {
+                    break;
+                }
+                bytes += cost;
+                selected.push(id.clone());
+            }
+
+            selected
+                .into_iter()
+                .filter_map(|id| slots.entities.remove(&id).map(|slot| slot.update))
+                .collect()
+        };
+
         Some(ClientStateFlush {
-            entities: slots.entities.drain().map(|(_, update)| update).collect(),
+            entities,
             peers: slots.peers.drain().map(|(_, peer)| peer).collect(),
             trace_ids: std::mem::take(&mut slots.trace_ids),
         })
+    }
+
+    /// Entity slots still pending for a client after a (budgeted) flush.
+    pub fn pending_entities(&self, client_id: &str) -> usize {
+        self.clients
+            .get(client_id)
+            .map(|slots| slots.entities.len())
+            .unwrap_or(0)
     }
 
     /// Total pending latest-value slots across all clients. Bounded by
@@ -343,34 +473,42 @@ mod tests {
         }
     }
 
+    fn stage(buffer: &mut ReplicatedStateBuffer, client_id: &str, update: EntityProtocol) {
+        buffer.stage_entity_update(client_id, update, 0.0, 0);
+    }
+
+    fn drain_all(buffer: &mut ReplicatedStateBuffer, client_id: &str) -> Option<ClientStateFlush> {
+        buffer.drain_client(client_id, EntityFlushBudget::UNLIMITED)
+    }
+
     #[test]
     fn newer_entity_state_overwrites_pending_state() {
         let mut buffer = ReplicatedStateBuffer::new();
-        buffer.stage_entity_update("client", update("bot", Some("old")));
-        buffer.stage_entity_update("client", update("bot", Some("new")));
+        stage(&mut buffer, "client", update("bot", Some("old")));
+        stage(&mut buffer, "client", update("bot", Some("new")));
 
-        let flush = buffer.drain_client("client").unwrap();
+        let flush = drain_all(&mut buffer, "client").unwrap();
         assert_eq!(flush.entities.len(), 1);
         assert_eq!(flush.entities[0].metadata.as_deref(), Some("new"));
-        assert!(buffer.drain_client("client").is_none());
+        assert!(drain_all(&mut buffer, "client").is_none());
     }
 
     #[test]
     fn keep_alive_never_clobbers_pending_metadata() {
         let mut buffer = ReplicatedStateBuffer::new();
-        buffer.stage_entity_update("client", update("bot", Some("pos")));
-        buffer.stage_entity_update("client", update("bot", None));
+        stage(&mut buffer, "client", update("bot", Some("pos")));
+        stage(&mut buffer, "client", update("bot", None));
 
-        let flush = buffer.drain_client("client").unwrap();
+        let flush = drain_all(&mut buffer, "client").unwrap();
         assert_eq!(flush.entities[0].metadata.as_deref(), Some("pos"));
     }
 
     #[test]
     fn keep_alive_fills_an_empty_slot() {
         let mut buffer = ReplicatedStateBuffer::new();
-        buffer.stage_entity_update("client", update("bot", None));
+        stage(&mut buffer, "client", update("bot", None));
 
-        let flush = buffer.drain_client("client").unwrap();
+        let flush = drain_all(&mut buffer, "client").unwrap();
         assert_eq!(flush.entities.len(), 1);
         assert!(flush.entities[0].metadata.is_none());
     }
@@ -378,10 +516,10 @@ mod tests {
     #[test]
     fn lifecycle_clear_prevents_stale_state_after_release() {
         let mut buffer = ReplicatedStateBuffer::new();
-        buffer.stage_entity_update("client", update("bot", Some("stale")));
+        stage(&mut buffer, "client", update("bot", Some("stale")));
         buffer.clear_entity("client", "bot");
 
-        assert!(buffer.drain_client("client").is_none());
+        assert!(drain_all(&mut buffer, "client").is_none());
     }
 
     #[test]
@@ -390,7 +528,7 @@ mod tests {
         buffer.stage_peer_update("client", peer("friend", "old"));
         buffer.stage_peer_update("client", peer("friend", "new"));
 
-        let flush = buffer.drain_client("client").unwrap();
+        let flush = drain_all(&mut buffer, "client").unwrap();
         assert_eq!(flush.peers.len(), 1);
         assert_eq!(flush.peers[0].metadata, "new");
     }
@@ -402,23 +540,27 @@ mod tests {
         buffer.stage_peer_update("b", peer("gone", "pos"));
         buffer.remove_peer("gone");
 
-        assert!(buffer.drain_client("a").is_none());
-        assert!(buffer.drain_client("b").is_none());
+        assert!(drain_all(&mut buffer, "a").is_none());
+        assert!(drain_all(&mut buffer, "b").is_none());
     }
 
     #[test]
     fn slot_cap_bounds_the_buffer_and_counts_drops() {
         let mut buffer = ReplicatedStateBuffer::new();
         for i in 0..MAX_STATE_SLOTS_PER_CLIENT {
-            buffer.stage_entity_update("client", update(&format!("bot-{}", i), Some("m")));
+            stage(
+                &mut buffer,
+                "client",
+                update(&format!("bot-{}", i), Some("m")),
+            );
         }
-        buffer.stage_entity_update("client", update("one-too-many", Some("m")));
+        stage(&mut buffer, "client", update("one-too-many", Some("m")));
 
         assert_eq!(buffer.total_pending(), MAX_STATE_SLOTS_PER_CLIENT);
         assert_eq!(buffer.dropped_updates(), 1);
 
         // Overwriting an existing slot is always allowed at the cap.
-        buffer.stage_entity_update("client", update("bot-0", Some("newer")));
+        stage(&mut buffer, "client", update("bot-0", Some("newer")));
         assert_eq!(buffer.total_pending(), MAX_STATE_SLOTS_PER_CLIENT);
         assert_eq!(buffer.dropped_updates(), 1);
     }
@@ -428,14 +570,165 @@ mod tests {
         // A gated client's slots persist and keep coalescing; the next
         // successful flush carries the newest snapshot only.
         let mut buffer = ReplicatedStateBuffer::new();
-        buffer.stage_entity_update("client", update("bot", Some("tick-1")));
+        stage(&mut buffer, "client", update("bot", Some("tick-1")));
         // Flush gated: nothing drained. Newer state arrives.
-        buffer.stage_entity_update("client", update("bot", Some("tick-2")));
-        buffer.stage_entity_update("client", update("bot", Some("tick-3")));
+        stage(&mut buffer, "client", update("bot", Some("tick-2")));
+        stage(&mut buffer, "client", update("bot", Some("tick-3")));
 
-        let flush = buffer.drain_client("client").unwrap();
+        let flush = drain_all(&mut buffer, "client").unwrap();
         assert_eq!(flush.entities.len(), 1);
         assert_eq!(flush.entities[0].metadata.as_deref(), Some("tick-3"));
+    }
+
+    #[test]
+    fn budget_caps_updates_per_flush_and_keeps_the_rest_pending() {
+        let mut buffer = ReplicatedStateBuffer::new();
+        for i in 0..10 {
+            buffer.stage_entity_update("client", update(&format!("bot-{}", i), Some("m")), 0.0, 1);
+        }
+
+        let budget = EntityFlushBudget {
+            max_updates: 4,
+            max_bytes: usize::MAX,
+        };
+        let flush = buffer.drain_client("client", budget).unwrap();
+        assert_eq!(flush.entities.len(), 4);
+        assert_eq!(buffer.pending_entities("client"), 6);
+
+        // The remainder drains over subsequent ticks; nothing is lost.
+        let mut remaining: Vec<String> = Vec::new();
+        while let Some(flush) = buffer.drain_client("client", budget) {
+            assert!(flush.entities.len() <= 4);
+            remaining.extend(flush.entities.into_iter().map(|update| update.id));
+        }
+        assert_eq!(remaining.len(), 6);
+        assert_eq!(buffer.pending_entities("client"), 0);
+    }
+
+    #[test]
+    fn byte_budget_bounds_a_flush_but_always_makes_progress() {
+        let mut buffer = ReplicatedStateBuffer::new();
+        let heavy = "x".repeat(1000);
+        for i in 0..5 {
+            buffer.stage_entity_update(
+                "client",
+                update(&format!("bot-{}", i), Some(&heavy)),
+                0.0,
+                1,
+            );
+        }
+
+        // A budget below a single update's cost still flushes one update.
+        let starved = EntityFlushBudget {
+            max_updates: usize::MAX,
+            max_bytes: 100,
+        };
+        let flush = buffer.drain_client("client", starved).unwrap();
+        assert_eq!(flush.entities.len(), 1);
+
+        // A budget worth roughly two updates flushes two.
+        let two_wide = EntityFlushBudget {
+            max_updates: usize::MAX,
+            max_bytes: 2100,
+        };
+        let flush = buffer.drain_client("client", two_wide).unwrap();
+        assert_eq!(flush.entities.len(), 2);
+        assert_eq!(buffer.pending_entities("client"), 2);
+    }
+
+    #[test]
+    fn budgeted_flush_is_oldest_first_then_nearest() {
+        let mut buffer = ReplicatedStateBuffer::new();
+        buffer.stage_entity_update("client", update("late-near", Some("m")), 1.0, 2);
+        buffer.stage_entity_update("client", update("early-far", Some("m")), 900.0, 1);
+        buffer.stage_entity_update("client", update("early-near", Some("m")), 1.0, 1);
+
+        let budget = EntityFlushBudget {
+            max_updates: 2,
+            max_bytes: usize::MAX,
+        };
+        let flush = buffer.drain_client("client", budget).unwrap();
+        let mut ids: Vec<&str> = flush.entities.iter().map(|u| u.id.as_str()).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec!["early-far", "early-near"]);
+        assert_eq!(buffer.pending_entities("client"), 1);
+    }
+
+    #[test]
+    fn coalescing_does_not_reset_a_slots_age() {
+        let mut buffer = ReplicatedStateBuffer::new();
+        buffer.stage_entity_update("client", update("old-timer", Some("v1")), 500.0, 1);
+        buffer.stage_entity_update("client", update("newcomer", Some("v1")), 1.0, 2);
+        // The old slot coalesces on a later tick, but keeps its tick-1 age
+        // and must still flush before the tick-2 newcomer.
+        buffer.stage_entity_update("client", update("old-timer", Some("v2")), 500.0, 2);
+
+        let budget = EntityFlushBudget {
+            max_updates: 1,
+            max_bytes: usize::MAX,
+        };
+        let flush = buffer.drain_client("client", budget).unwrap();
+        assert_eq!(flush.entities[0].id, "old-timer");
+        assert_eq!(flush.entities[0].metadata.as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn a_representative_150_entity_scene_stays_bounded_and_starvation_free() {
+        // Mirrors the observed staging incident: ~150 tracked entities whose
+        // metadata (~800 bytes each) changes every tick used to flush as one
+        // ~120 KB frame per tick. Under the default-sized budget every flush
+        // stays bounded, the pending set never exceeds the interest set, and
+        // every entity still replicates within a few ticks.
+        const ENTITIES: usize = 150;
+        const TICKS: u64 = 120;
+        let budget = EntityFlushBudget {
+            max_updates: 64,
+            max_bytes: 24 * 1024,
+        };
+        let metadata = "m".repeat(800);
+
+        let mut buffer = ReplicatedStateBuffer::new();
+        let mut last_flushed: HashMap<String, u64> = HashMap::new();
+        let mut max_gap = 0;
+
+        for tick in 1..=TICKS {
+            for i in 0..ENTITIES {
+                buffer.stage_entity_update(
+                    "client",
+                    update(&format!("bot-{:03}", i), Some(&metadata)),
+                    (i * i) as f32,
+                    tick,
+                );
+            }
+            assert!(buffer.total_pending() <= ENTITIES);
+
+            let flush = buffer.drain_client("client", budget).unwrap();
+            assert!(flush.entities.len() <= budget.max_updates);
+            let bytes: usize = flush
+                .entities
+                .iter()
+                .map(|u| u.id.len() + u.r#type.len() + u.metadata.as_ref().map_or(0, String::len))
+                .sum();
+            assert!(bytes <= budget.max_bytes);
+
+            for update in &flush.entities {
+                let last = last_flushed.insert(update.id.clone(), tick).unwrap_or(0);
+                if tick > 10 {
+                    max_gap = max_gap.max(tick - last);
+                }
+            }
+        }
+
+        // Every entity was flushed, and the aged rotation revisits each one
+        // within ceil(150 / 30-per-flush) = 5 ticks (plus one tick of slack).
+        assert_eq!(last_flushed.len(), ENTITIES);
+        assert!(max_gap <= 6, "rotation gap too large: {}", max_gap);
+
+        // An entity that stops changing is not re-staged and never resends:
+        // drain the backlog dry, stage nothing, and the buffer stays silent.
+        while buffer.drain_client("client", budget).is_some() {}
+        assert!(buffer.drain_client("client", budget).is_none());
+        assert_eq!(buffer.pending_entities("client"), 0);
     }
 
     #[test]

--- a/server/world/replication/mod.rs
+++ b/server/world/replication/mod.rs
@@ -38,7 +38,8 @@
 //!   when more entity slots are pending than the budget allows, the oldest
 //!   staged slots flush first (nearest first within the same age) and the
 //!   rest stay pending — still coalescing — for subsequent ticks. This bounds
-//!   the bytes a single tick can put on one client's socket, no matter how
+//!   the entity-state *payload* a single tick can put on one client's socket
+//!   (approximately — see [`EntityFlushBudget::max_bytes`]), no matter how
 //!   many tracked entities changed at once;
 //! - when a client's socket is backed up, flushing is **skipped** for that
 //!   client while its slots keep coalescing, so the moment the socket drains
@@ -95,7 +96,12 @@ const MAX_PENDING_TRACE_IDS: usize = 8;
 pub struct EntityFlushBudget {
     /// Maximum entity UPDATEs in one flush.
     pub max_updates: usize,
-    /// Maximum summed wire cost (id + type + metadata bytes) in one flush.
+    /// Approximate payload budget: the maximum summed [`EntitySlot::wire_cost`]
+    /// (id + type + metadata string bytes) in one flush. This is NOT the
+    /// encoded protobuf frame size — protobuf field/frame overhead can push
+    /// the frame above it, and a single update whose payload alone exceeds it
+    /// still ships (forced progress). Measure actual frame sizes with the
+    /// `entity_batch_send.byteSize` perf field, not this budget.
     pub max_bytes: usize,
 }
 
@@ -284,9 +290,14 @@ impl ReplicatedStateBuffer {
     /// updates/bytes. Entity slots beyond the budget stay pending (and keep
     /// coalescing); selection is deterministic — oldest staged tick first,
     /// nearest first within the same tick, entity id as the final tiebreak —
-    /// so every pending slot flushes within `pending / max_updates` ticks and
-    /// no entity can be starved. Peer snapshots are few and latency-critical,
-    /// so they always flush in full. Returns `None` when nothing is pending.
+    /// so no entity can be starved: the oldest pending slot is always flushed
+    /// next. How many ticks a pending slot waits depends on BOTH limits (the
+    /// item cap and the payload-byte cap relative to actual payload sizes),
+    /// so there is no universal `pending / max_updates` latency bound — size
+    /// the budget against the expected interest set and payloads (the 150 x
+    /// ~800 B scene test observes a <= 6 tick revisit gap under the
+    /// defaults). Peer snapshots are few and latency-critical, so they
+    /// always flush in full. Returns `None` when nothing is pending.
     pub fn drain_client(
         &mut self,
         client_id: &str,
@@ -678,7 +689,9 @@ mod tests {
         // metadata (~800 bytes each) changes every tick used to flush as one
         // ~120 KB frame per tick. Under the default-sized budget every flush
         // stays bounded, the pending set never exceeds the interest set, and
-        // every entity still replicates within a few ticks.
+        // — for THIS scene's payload sizes under the default budget — every
+        // entity is revisited within a few ticks (observed <= 6 below; the
+        // revisit latency is scene-dependent, not a universal bound).
         const ENTITIES: usize = 150;
         const TICKS: u64 = 120;
         let budget = EntityFlushBudget {
@@ -719,8 +732,10 @@ mod tests {
             }
         }
 
-        // Every entity was flushed, and the aged rotation revisits each one
-        // within ceil(150 / 30-per-flush) = 5 ticks (plus one tick of slack).
+        // Every entity was flushed. For this scene the byte cap is the
+        // binding limit (~30 updates of ~810 B payload per flush), so the
+        // aged rotation revisits each entity within ceil(150 / 30) = 5 ticks
+        // (plus one tick of slack).
         assert_eq!(last_flushed.len(), ENTITIES);
         assert!(max_gap <= 6, "rotation gap too large: {}", max_gap);
 

--- a/server/world/systems/broadcast.rs
+++ b/server/world/systems/broadcast.rs
@@ -10,10 +10,10 @@ use crate::{
     server::Message,
     world::{
         profiler::Profiler, system_profiler::WorldTimingContext, Client, Clients, MessageQueues,
-        Stats,
+        Stats, WorldConfig,
     },
-    EncodedMessage, EncodedMessageQueue, EntityOperation, MessageType, ReplicatedStateBuffer,
-    RtcSenders, Transports, STATE_FLUSH_MAX_SOCKET_BACKLOG,
+    EncodedMessage, EncodedMessageQueue, EntityFlushBudget, EntityOperation, MessageType,
+    ReplicatedStateBuffer, RtcSenders, Transports, STATE_FLUSH_MAX_SOCKET_BACKLOG,
 };
 
 pub struct BroadcastSystem;
@@ -203,6 +203,7 @@ impl<'a> System<'a> for BroadcastSystem {
         ReadExpect<'a, Clients>,
         ReadExpect<'a, WorldTimingContext>,
         ReadExpect<'a, Stats>,
+        ReadExpect<'a, WorldConfig>,
         WriteExpect<'a, MessageQueues>,
         WriteExpect<'a, EncodedMessageQueue>,
         WriteExpect<'a, ReplicatedStateBuffer>,
@@ -216,6 +217,7 @@ impl<'a> System<'a> for BroadcastSystem {
             clients,
             timing,
             stats,
+            config,
             mut queues,
             mut encoded_queue,
             mut replicated_state,
@@ -340,10 +342,18 @@ impl<'a> System<'a> for BroadcastSystem {
         // A client whose socket is backed up is skipped ("gated"): its slots
         // stay in the buffer and keep being overwritten by newer values, so
         // when the socket drains it receives one current snapshot instead of
-        // a replay of stale positions. This is what keeps the outbound path
-        // bounded — see `world::replication` before changing it.
+        // a replay of stale positions. Each flush is additionally budgeted
+        // (items and bytes per tick, oldest-staged first, nearest first
+        // within the same age), so a scene where every tracked entity changes
+        // each tick can never put an unbounded frame on one client's socket.
+        // This is what keeps the outbound path bounded — see
+        // `world::replication` before changing it.
         let tick = stats.tick;
         let mut gated_clients = 0;
+        let flush_budget = EntityFlushBudget {
+            max_updates: config.max_entity_updates_per_tick,
+            max_bytes: config.max_entity_update_bytes_per_tick,
+        };
 
         for (client_id, client) in clients.iter() {
             let rtc_sender = rtc_map.as_ref().and_then(|rtc_map| rtc_map.get(client_id));
@@ -359,7 +369,7 @@ impl<'a> System<'a> for BroadcastSystem {
                 continue;
             }
 
-            let Some(flush) = replicated_state.drain_client(client_id) else {
+            let Some(flush) = replicated_state.drain_client(client_id, flush_budget) else {
                 continue;
             };
 
@@ -386,6 +396,7 @@ impl<'a> System<'a> for BroadcastSystem {
                             "tick": tick,
                             "itemCount": flush.entities.len(),
                             "byteSize": data.len(),
+                            "pendingAfterFlush": replicated_state.pending_entities(client_id),
                             "outboundQueueDepth": client.sender.len(),
                             "connectionOutboundQueueDepths": depths,
                         }),

--- a/server/world/systems/broadcast.rs
+++ b/server/world/systems/broadcast.rs
@@ -343,9 +343,10 @@ impl<'a> System<'a> for BroadcastSystem {
         // stay in the buffer and keep being overwritten by newer values, so
         // when the socket drains it receives one current snapshot instead of
         // a replay of stale positions. Each flush is additionally budgeted
-        // (items and bytes per tick, oldest-staged first, nearest first
-        // within the same age), so a scene where every tracked entity changes
-        // each tick can never put an unbounded frame on one client's socket.
+        // (items and approximate payload bytes per tick, oldest-staged first,
+        // nearest first within the same age), so a scene where every tracked
+        // entity changes each tick can never put an unbounded frame on one
+        // client's socket.
         // This is what keeps the outbound path bounded — see
         // `world::replication` before changing it.
         let tick = stats.tick;

--- a/server/world/systems/entity/sending.rs
+++ b/server/world/systems/entity/sending.rs
@@ -19,6 +19,15 @@ pub struct EntitiesSendingSystem {
     new_entity_ids_buffer: HashSet<String>,
 }
 
+/// Per-client output of one tick: lifecycle transitions (reliable events) and
+/// state UPDATEs paired with the squared client-to-entity distance the
+/// budgeted state flush orders by.
+#[derive(Default)]
+struct ClientUpdates {
+    lifecycle: Vec<EntityProtocol>,
+    state: Vec<(EntityProtocol, f32)>,
+}
+
 impl<'a> System<'a> for EntitiesSendingSystem {
     type SystemData = (
         Entities<'a>,
@@ -167,7 +176,7 @@ impl<'a> System<'a> for EntitiesSendingSystem {
             );
         }
 
-        let mut client_updates: HashMap<String, Vec<EntityProtocol>> = HashMap::new();
+        let mut client_updates: HashMap<String, ClientUpdates> = HashMap::new();
 
         for (id, etype, metadata) in &deleted_entities {
             for client_id in clients.keys() {
@@ -175,6 +184,7 @@ impl<'a> System<'a> for EntitiesSendingSystem {
                     client_updates
                         .entry(client_id.clone())
                         .or_default()
+                        .lifecycle
                         .push(EntityProtocol {
                             operation: EntityOperation::Delete,
                             id: id.clone(),
@@ -204,7 +214,7 @@ impl<'a> System<'a> for EntitiesSendingSystem {
                             .get(entity_id)
                             .map(|(etype, ..)| etype.clone())
                             .unwrap_or_default();
-                        updates.push(EntityProtocol {
+                        updates.lifecycle.push(EntityProtocol {
                             operation: EntityOperation::OutOfRange,
                             id: entity_id.clone(),
                             r#type: old_etype,
@@ -215,14 +225,18 @@ impl<'a> System<'a> for EntitiesSendingSystem {
 
                     // Block entities are chunk-bound: every client keeps them
                     // for as long as they exist, with change-driven updates.
+                    // Distance zero gives their rare updates flush priority.
                     if etype.starts_with(BLOCK_ENTITY_PREFIX) {
                         if changed_metadata_ids.contains(entity_id) {
-                            updates.push(EntityProtocol {
-                                operation: EntityOperation::Update,
-                                id: entity_id.clone(),
-                                r#type: etype.clone(),
-                                metadata: Some(json_str.clone()),
-                            });
+                            updates.state.push((
+                                EntityProtocol {
+                                    operation: EntityOperation::Update,
+                                    id: entity_id.clone(),
+                                    r#type: etype.clone(),
+                                    metadata: Some(json_str.clone()),
+                                },
+                                0.0,
+                            ));
                             *last_sent_tick = tick;
                         }
                         return true;
@@ -240,7 +254,7 @@ impl<'a> System<'a> for EntitiesSendingSystem {
 
                     match classify_interest(true, distance_sq, visible_radius, release_radius) {
                         InterestTransition::Leave => {
-                            updates.push(EntityProtocol {
+                            updates.lifecycle.push(EntityProtocol {
                                 operation: EntityOperation::OutOfRange,
                                 id: entity_id.clone(),
                                 r#type: etype.clone(),
@@ -250,20 +264,26 @@ impl<'a> System<'a> for EntitiesSendingSystem {
                         }
                         _ => {
                             if changed_metadata_ids.contains(entity_id) {
-                                updates.push(EntityProtocol {
-                                    operation: EntityOperation::Update,
-                                    id: entity_id.clone(),
-                                    r#type: etype.clone(),
-                                    metadata: Some(json_str.clone()),
-                                });
+                                updates.state.push((
+                                    EntityProtocol {
+                                        operation: EntityOperation::Update,
+                                        id: entity_id.clone(),
+                                        r#type: etype.clone(),
+                                        metadata: Some(json_str.clone()),
+                                    },
+                                    distance_sq,
+                                ));
                                 *last_sent_tick = tick;
                             } else if tick.saturating_sub(*last_sent_tick) >= keep_alive_interval {
-                                updates.push(EntityProtocol {
-                                    operation: EntityOperation::Update,
-                                    id: entity_id.clone(),
-                                    r#type: etype.clone(),
-                                    metadata: None,
-                                });
+                                updates.state.push((
+                                    EntityProtocol {
+                                        operation: EntityOperation::Update,
+                                        id: entity_id.clone(),
+                                        r#type: etype.clone(),
+                                        metadata: None,
+                                    },
+                                    distance_sq,
+                                ));
                                 *last_sent_tick = tick;
                             }
                             true
@@ -292,6 +312,7 @@ impl<'a> System<'a> for EntitiesSendingSystem {
                 client_updates
                     .entry(client_id.clone())
                     .or_default()
+                    .lifecycle
                     .push(EntityProtocol {
                         operation: EntityOperation::Create,
                         id: id.0.clone(),
@@ -322,6 +343,7 @@ impl<'a> System<'a> for EntitiesSendingSystem {
                 client_updates
                     .entry(client_id.clone())
                     .or_default()
+                    .lifecycle
                     .push(EntityProtocol {
                         operation: EntityOperation::Create,
                         id: entity_id.clone(),
@@ -341,15 +363,10 @@ impl<'a> System<'a> for EntitiesSendingSystem {
         // never miss — they go through the FIFO message queue. UPDATEs are
         // latest-wins STATE — they go into the per-client, per-entity slot
         // buffer, where a newer value overwrites an undelivered older one so
-        // a backed-up client can never receive a replay of stale positions.
+        // a backed-up client can never receive a replay of stale positions,
+        // and the broadcast system flushes them under a per-tick budget.
         for (client_id, updates) in client_updates {
-            if updates.is_empty() {
-                continue;
-            }
-
-            let (lifecycle, state_updates): (Vec<_>, Vec<_>) = updates
-                .into_iter()
-                .partition(|update| update.operation != EntityOperation::Update);
+            let ClientUpdates { lifecycle, state } = updates;
 
             if !lifecycle.is_empty() {
                 for update in &lifecycle {
@@ -363,43 +380,297 @@ impl<'a> System<'a> for EntitiesSendingSystem {
                     .entities(&lifecycle)
                     .tick(tick);
                 if perf::is_enabled() {
-                    let trace_id =
-                        log_entity_batch_queue(&timing.world_name, tick, &client_id, &lifecycle);
+                    let trace_id = log_entity_batch_queue(
+                        &timing.world_name,
+                        tick,
+                        &client_id,
+                        lifecycle.iter(),
+                    );
                     message = message
                         .json(&serde_json::json!({ "townPerfTraceId": trace_id }).to_string());
                 }
                 queue.push((message.build(), ClientFilter::Direct(client_id.clone())));
             }
 
-            if !state_updates.is_empty() {
+            if !state.is_empty() {
                 if perf::is_enabled() {
                     let trace_id = log_entity_batch_queue(
                         &timing.world_name,
                         tick,
                         &client_id,
-                        &state_updates,
+                        state.iter().map(|(update, _)| update),
                     );
                     replicated_state.note_trace_id(&client_id, trace_id);
                 }
-                for update in state_updates {
-                    replicated_state.stage_entity_update(&client_id, update);
+                for (update, distance_sq) in state {
+                    replicated_state.stage_entity_update(&client_id, update, distance_sq, tick);
                 }
             }
         }
     }
 }
 
-fn log_entity_batch_queue(
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Client, WorldConfig, WsSender};
+    use serde_json::json;
+    use specs::{Builder, RunNow, World, WorldExt};
+
+    const CLIENT_ID: &str = "client";
+
+    fn make_world(entity_count: usize) -> World {
+        let mut world = World::new();
+
+        world.register::<EntityFlag>();
+        world.register::<IDComp>();
+        world.register::<ETypeComp>();
+        world.register::<InteractorComp>();
+        world.register::<DoNotPersistComp>();
+        world.register::<PositionComp>();
+        world.register::<VoxelComp>();
+        world.register::<MetadataComp>();
+
+        let config = WorldConfig::new().build();
+        world.insert(BackgroundEntitiesSaver::new(&config));
+        world.insert(WorldTimingContext::new("test"));
+        world.insert(Stats::new(false, "", 0.0));
+        world.insert(MessageQueues::new());
+        world.insert(ReplicatedStateBuffer::new());
+        world.insert(Bookkeeping::new());
+        world.insert(Physics::new());
+        world.insert(EntityIDs::new());
+        world.insert(config);
+
+        let client_entity = world
+            .create_entity()
+            .with(PositionComp::new(0.0, 0.0, 0.0))
+            .build();
+
+        let (control, _control_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (bulk, _bulk_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut clients = Clients::new();
+        clients.insert(
+            CLIENT_ID.to_owned(),
+            Client {
+                id: CLIENT_ID.to_owned(),
+                username: CLIENT_ID.to_owned(),
+                entity: client_entity,
+                sender: WsSender::new(control, bulk),
+            },
+        );
+        world.insert(clients);
+
+        let mut kdtree = KdTree::new();
+        for i in 0..entity_count {
+            let position = Vec3(i as f32 + 1.0, 0.0, 0.0);
+            let mut metadata = MetadataComp::new();
+            metadata.set_value("position", json!([position.0, position.1, position.2]));
+
+            let entity = world
+                .create_entity()
+                .with(EntityFlag)
+                .with(IDComp::new(&format!("bot-{}", i)))
+                .with(ETypeComp::new("bot", false))
+                .with(PositionComp::new(position.0, position.1, position.2))
+                .with(metadata)
+                .build();
+            kdtree.add_entity(entity, position);
+        }
+        world.insert(kdtree);
+        world.maintain();
+
+        world
+    }
+
+    fn run_tick(world: &mut World, tick: u64) {
+        world.write_resource::<Stats>().tick = tick;
+        EntitiesSendingSystem::default().run_now(world);
+    }
+
+    fn drain_queued_entity_ops(world: &World) -> Vec<EntityProtocol> {
+        let mut queues = world.write_resource::<MessageQueues>();
+        queues
+            .drain_prioritized()
+            .into_iter()
+            .flat_map(|(message, _)| message.entities)
+            .map(|entity| EntityProtocol {
+                operation: EntityOperation::try_from(entity.operation).unwrap(),
+                id: entity.id,
+                r#type: entity.r#type,
+                metadata: if entity.metadata.is_empty() {
+                    None
+                } else {
+                    Some(entity.metadata)
+                },
+            })
+            .collect()
+    }
+
+    #[test]
+    fn unchanged_entities_do_not_resend_every_tick() {
+        let mut world = make_world(150);
+
+        // Tick 1: all 150 entities enter the client's interest set as
+        // reliable CREATEs carrying their full snapshot — the client's
+        // complete initial state.
+        run_tick(&mut world, 1);
+        let created = drain_queued_entity_ops(&world);
+        assert_eq!(created.len(), 150);
+        assert!(created
+            .iter()
+            .all(|op| op.operation == EntityOperation::Create && op.metadata.is_some()));
+        assert_eq!(
+            world
+                .read_resource::<ReplicatedStateBuffer>()
+                .total_pending(),
+            0
+        );
+
+        // Ticks 2-10: no metadata changed, so nothing is queued and nothing
+        // is staged — unchanged entities are silent until their keep-alive.
+        for tick in 2..=10 {
+            run_tick(&mut world, tick);
+            assert!(drain_queued_entity_ops(&world).is_empty());
+            assert_eq!(
+                world
+                    .read_resource::<ReplicatedStateBuffer>()
+                    .total_pending(),
+                0,
+                "unchanged entities were re-staged on tick {}",
+                tick
+            );
+        }
+    }
+
+    #[test]
+    fn only_the_changed_entity_is_staged() {
+        let mut world = make_world(150);
+        run_tick(&mut world, 1);
+        drain_queued_entity_ops(&world);
+
+        {
+            let ids = world.read_storage::<IDComp>();
+            let mut metadatas = world.write_storage::<MetadataComp>();
+            use specs::Join;
+            for (id, metadata) in (&ids, &mut metadatas).join() {
+                if id.0 == "bot-7" {
+                    metadata.set_value("position", json!([99.0, 0.0, 0.0]));
+                }
+            }
+        }
+
+        run_tick(&mut world, 2);
+        assert!(drain_queued_entity_ops(&world).is_empty());
+
+        let mut buffer = world.write_resource::<ReplicatedStateBuffer>();
+        let flush = buffer
+            .drain_client(CLIENT_ID, crate::EntityFlushBudget::UNLIMITED)
+            .unwrap();
+        assert_eq!(flush.entities.len(), 1);
+        assert_eq!(flush.entities[0].id, "bot-7");
+        assert_eq!(flush.entities[0].operation, EntityOperation::Update);
+    }
+
+    #[test]
+    fn a_changing_150_entity_scene_flushes_bounded_bytes_per_tick() {
+        // Reproduces the observed incident shape: ~150 tracked entities whose
+        // metadata (~800 bytes each) changes every tick. Draining without a
+        // budget shows the old per-tick frame (~120 KB); draining with the
+        // default budget bounds every flush.
+        let mut world = make_world(150);
+
+        fn mutate_all(world: &mut World, tick: u64) {
+            use specs::Join;
+            let mut metadatas = world.write_storage::<MetadataComp>();
+            let flags = world.read_storage::<EntityFlag>();
+            for (metadata, _) in (&mut metadatas, &flags).join() {
+                metadata.set_value("position", json!([tick as f32, 0.0, 0.0]));
+                metadata.set_value("blob", json!("p".repeat(760)));
+            }
+        }
+
+        fn wire_bytes(updates: &[EntityProtocol]) -> usize {
+            updates
+                .iter()
+                .map(|u| u.id.len() + u.r#type.len() + u.metadata.as_ref().map_or(0, String::len))
+                .sum()
+        }
+
+        run_tick(&mut world, 1);
+        assert_eq!(drain_queued_entity_ops(&world).len(), 150);
+
+        // Before: one unbudgeted drain carries the whole changed scene.
+        mutate_all(&mut world, 2);
+        run_tick(&mut world, 2);
+        let before = {
+            let mut buffer = world.write_resource::<ReplicatedStateBuffer>();
+            let flush = buffer
+                .drain_client(CLIENT_ID, crate::EntityFlushBudget::UNLIMITED)
+                .unwrap();
+            wire_bytes(&flush.entities)
+        };
+        assert!(
+            before > 100_000,
+            "expected the unbudgeted scene to exceed 100 KB, got {} bytes",
+            before
+        );
+
+        // After: the default budget bounds every tick's flush.
+        let budget = {
+            let config = world.read_resource::<WorldConfig>();
+            crate::EntityFlushBudget {
+                max_updates: config.max_entity_updates_per_tick,
+                max_bytes: config.max_entity_update_bytes_per_tick,
+            }
+        };
+        for tick in 3..=12 {
+            mutate_all(&mut world, tick);
+            run_tick(&mut world, tick);
+            let mut buffer = world.write_resource::<ReplicatedStateBuffer>();
+            let flush = buffer.drain_client(CLIENT_ID, budget).unwrap();
+            assert!(flush.entities.len() <= budget.max_updates);
+            assert!(
+                wire_bytes(&flush.entities) <= budget.max_bytes,
+                "budgeted flush exceeded the byte budget on tick {}",
+                tick
+            );
+        }
+    }
+
+    #[test]
+    fn unchanged_entities_keep_alive_without_metadata() {
+        let mut world = make_world(3);
+        let keep_alive_interval = world
+            .read_resource::<WorldConfig>()
+            .entity_keep_alive_interval;
+
+        run_tick(&mut world, 1);
+        drain_queued_entity_ops(&world);
+
+        run_tick(&mut world, 1 + keep_alive_interval);
+        let mut buffer = world.write_resource::<ReplicatedStateBuffer>();
+        let flush = buffer
+            .drain_client(CLIENT_ID, crate::EntityFlushBudget::UNLIMITED)
+            .unwrap();
+        assert_eq!(flush.entities.len(), 3);
+        assert!(flush.entities.iter().all(|op| op.metadata.is_none()));
+    }
+}
+
+fn log_entity_batch_queue<'a>(
     world_name: &str,
     tick: u64,
     client_id: &str,
-    updates: &[EntityProtocol],
+    updates: impl Iterator<Item = &'a EntityProtocol>,
 ) -> String {
     let trace_id = perf::next_trace_id("entity");
-    let metadata_bytes = updates
-        .iter()
-        .map(|update| update.metadata.as_ref().map_or(0, String::len))
-        .sum::<usize>();
+    let mut item_count = 0;
+    let mut metadata_bytes = 0;
+    for update in updates {
+        item_count += 1;
+        metadata_bytes += update.metadata.as_ref().map_or(0, String::len);
+    }
     perf::log(
         "entity_batch_queue",
         world_name,
@@ -407,7 +678,7 @@ fn log_entity_batch_queue(
             "traceId": trace_id,
             "tick": tick,
             "clientId": client_id,
-            "itemCount": updates.len(),
+            "itemCount": item_count,
             "metadataBytes": metadata_bytes,
         }),
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Fix recurring entity-broadcast outbound pressure (Town staging lobby2 incident)

## Incident shape

A guest client on Town staging lobby2 received 133–156 entity batches at ~118–129 KB **every tick**, its per-connection outbound queue depth climbed 5 → 9, and the client fell behind and disconnected. Core stayed up.

## Root cause

Three engine facts compound on current `main`:

1. **Every live entity's metadata "changes" every tick.** `EntitiesMetaSystem` (and the path/target metadata systems) rewrite `position` / `rigidBody` / `path` each tick; any float movement — including sub-visual jitter from collision repulsion between crowded entities — flips `MetadataComp::to_cached_str`'s whole-JSON change check, so the entity is re-staged for every interested client. (The 300-box repro below shows entities that *look* settled still jostling for ~28 s.)
2. **The default interest radius is enormous** (24 chunks = 384 blocks), so one lobby client tracks essentially every entity in the zoo.
3. **The state flush had no volume bound.** `BroadcastSystem` drained *all* of a client's pending latest-wins slots into one ENTITY frame per tick. ~150 changed entities × ~800 B metadata ≈ 120 KB per tick per client — exactly the observed batches. The only backpressure was the flush gate at control-lane backlog > 8, i.e. ~1 MB of queued 120 KB frames before gating; a marginal link oscillates 5 → 9 and dies.

History check: a mitigation with per-client revisions + nearest-first + per-tick cap landed in `15d54a435` and was **reverted 11 minutes later** (`6c59444f1`). The replacement latest-wins replication layer (`c0b206a7d`, PR #107 line) correctly bounds *replay* (no stale-frame queues) but never restored *volume* control. This PR adds the volume bound where it now belongs — in the latest-wins buffer — instead of resurrecting the reverted FIFO-era design.

## Fix

Per-client, per-tick **flush budget** on the latest-wins entity state channel (`ReplicatedStateBuffer::drain_client`):

- New `WorldConfig` knobs: `max_entity_updates_per_tick` (default **64**) and `max_entity_update_bytes_per_tick` (default **24 KiB**), both builder-configurable and validated positive.
- `max_entity_update_bytes_per_tick` is an **approximate entity-state payload budget**: it caps the summed `wire_cost` (id + type + metadata string bytes) selected into one flush, not the encoded protobuf frame size. Protobuf field/frame overhead can push the actual frame above it, and a single update whose payload alone exceeds it still ships (forced progress, so the rotation can never wedge). For staging perf gates, measure the real encoded frame via the `entity_batch_send.byteSize` perf field, not this budget.
- Slots beyond the budget **stay pending and keep coalescing** to their newest value — nothing is dropped, nothing stale is ever replayed.
- Selection is deterministic and **starvation-free**: oldest staged tick first, nearest first within the same tick, entity id as final tiebreak; coalescing preserves a slot's original age, so the oldest pending slot is always flushed next. The revisit latency of a changing far entity is *not* a universal `pending / max_updates` tick bound — it depends on both the item cap and the payload-byte cap relative to actual payload sizes. Size the budgets so a full rotation of the expected interest set completes comfortably inside the client staleness timeout; the 150 × ~800 B scene test observes a ≤ 6 tick revisit gap under the defaults (byte cap binding at ~30 updates/flush).
- **Correctness-critical traffic is untouched:** CREATE / DELETE / OUT_OF_RANGE lifecycle events remain reliable, ordered, and unbudgeted (new clients still get their complete initial state in one frame; despawns/removals are never delayed behind state); keep-alives still never clobber pending metadata; `clear_entity` still prevents post-lifecycle resurrection; peer snapshots (few, latency-critical) flush in full.
- No new per-tick allocation storms: the budgeted path sorts only when over budget (`O(pending log pending)` on the client's interest set, ≤ a few hundred entries), and the in-budget fast path drains exactly as before.
- Instrumentation: `entity_batch_send` perf events now include `pendingAfterFlush`.

Unchanged entities already did not resend (whole-JSON change cache + 60-tick keep-alive) — this is now locked in by tests at both the metadata and the full-system level, and the budget bounds the genuinely-changing case that produced the incident.

## Before / after (real server + real browser client)

Reproduced with the example client on the `flat` world: one keypress spawns a wave of 300 physics boxes (temporary repro harness, not committed). "Before" = budget disabled (identical drain-all path to pre-fix `main`); "after" = defaults. `TOWN_PERF_LOG=1` capture of `entity_batch_send` (actual encoded frame bytes) to the single connected client:

| | before (unbounded) | after (default budget) |
|---|---|---|
| state flush itemCount p50 / p99 / max | 8 / 300 / 600 | 64 / 64 / 64 |
| state flush byteSize p99 / max | 11.1 KB / 40.2 KB | 2.5 KB / 11.0 KB¹ |
| peak entity bytes/sec to the client | **975 KB/s** | **94 KB/s** |
| sustained while boxes jostle | ~298-item ~11 KB frame *every tick* for ~28 s | ≤64-item ≤2.5 KB frames, rest coalesces |
| after settling | keep-alive waves | keep-alive waves (≤64 items, ≤2 KB, ~7 sends/s) |

¹ the 11 KB max is the single reliable 300×CREATE frame delivering complete initial state on spawn — intended and unbudgeted.

Client-side verification: all 300 boxes spawn, fall smoothly, and settle correctly with the budget active — no floating, missing, or frozen entities (video below).

<a href="https://cursor.com/agents/bc-a065dc6f-d278-403a-acf9-50e3090d9188/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbudgeted_entity_flush_300_box_wave_demo.mp4"><img src="https://cursor.com/artifacts/c/art-d5f1c227-2a20-4f74-8c5d-a9f7c82a239f" alt="budgeted_entity_flush_300_box_wave_demo.mp4" /></a>

![300 boxes falling with budgeted replication](https://cursor.com/artifacts/c/art-f725cab5-80ed-4974-8064-6ccaedfd0d37)
![Boxes settled correctly on the terrain](https://cursor.com/artifacts/c/art-89fdcbd9-8a6b-4fb4-9015-41963e85b225)

## Tests

- `replication::tests` — budget item/byte caps, forced progress on oversized updates, oldest-first + nearest-first ordering, age preservation across coalescing, and `a_representative_150_entity_scene_stays_bounded_and_starvation_free` (150 × 800 B changing every tick: every flush ≤ budget, pending ≤ interest size, observed max revisit gap ≤ 6 ticks under the defaults for this scene, silence once entities stop changing).
- `systems::entity::sending::tests` — new specs-World harness running the real `EntitiesSendingSystem` with a real client + 150 entities: unchanged entities queue/stage **nothing** tick after tick; only a changed entity is staged; keep-alives are metadata-less; `a_changing_150_entity_scene_flushes_bounded_bytes_per_tick` shows the unbudgeted drain exceeding 100 KB of payload and every budgeted flush within bounds.
- `components::metadata::tests` — whole-JSON change cache: unchanged → no update, changed → exactly one, `mark_dirty` re-emits.

## Relationship to other work

- PR #110 (zoo-join reliability: rejoin chunk resync, WS ack tolerance — the `bc-3c64fd27` agent's engine work) is already merged and is this branch's base; no rebase or file overlap. It reduces reconnect churn but does not address oversized entity sends — the two fixes are independent and complementary, as expected.
- No Town gameplay changes; strict engine-layer (transport/replication) fix. Town can tune the two new knobs per world if its entity payloads differ from the defaults.

## Checks

- `cargo test --lib --tests` — 82 passed, 0 failed
- `pnpm test` (vitest) — 92 passed
- `cargo check --all-targets` clean; `cargo fmt --check` introduces no new diffs (pre-existing diffs on `main` untouched)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a065dc6f-d278-403a-acf9-50e3090d9188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a065dc6f-d278-403a-acf9-50e3090d9188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

