### PR TITLE
fix(core): isolate entity apply errors and never construct from partial snapshots

### DIFF
--- a/packages/core/src/core/entities.test.ts
+++ b/packages/core/src/core/entities.test.ts
@@ -44,13 +44,23 @@ function entityMessage(
   operation: "CREATE" | "UPDATE" | "DELETE" | "OUT_OF_RANGE",
   id: string,
   metadata: Partial<ProbeData> | null = { position: [0, 0, 0] },
-  options: { motion?: EntityMotionProtocol; tick?: number } = {},
+  options: {
+    motion?: EntityMotionProtocol;
+    tick?: number;
+    type?: string;
+  } = {},
 ): MessageProtocol {
   return {
     type: "ENTITY",
     tick: options.tick,
     entities: [
-      { operation, id, type: "probe", metadata, motion: options.motion },
+      {
+        operation,
+        id,
+        type: options.type ?? "probe",
+        metadata,
+        motion: options.motion,
+      },
     ],
   } as MessageProtocol;
 }
@@ -349,6 +359,40 @@ describe("Entities resilience with Town-like consumers", () => {
     const healthy = entities.getEntityById("healthy") as ProbeEntity;
     expect(healthy.updateCount).toBe(1);
     expect(healthy.metadata!.position).toEqual([9, 9, 9]);
+  });
+
+  it("degrades an update whose motion failed to decode without ever losing position", () => {
+    const entities = makeTownEntities();
+    entities.onMessage(
+      entityMessage(
+        "CREATE",
+        "a",
+        { position: [1, 2, 3], name: "keeper" },
+        { type: "town" },
+      ),
+    );
+    const town = entities.getEntityById("a") as DestructuringEntity;
+
+    // The decode worker strips undecodable motion, so the update arrives
+    // with neither metadata nor motion: a keep-alive. Nothing applies.
+    expect(() =>
+      entities.onMessage(entityMessage("UPDATE", "a", null, { type: "town" })),
+    ).not.toThrow();
+    expect(town.applied).toEqual([[1, 2, 3]]);
+
+    // Same stripping with partial metadata attached: the merge keeps the
+    // accumulated position; the consumer never sees an undefined position.
+    entities.onMessage(
+      entityMessage("UPDATE", "a", { name: "renamed" }, { type: "town" }),
+    );
+    expect(town.applied).toEqual([
+      [1, 2, 3],
+      [1, 2, 3],
+    ]);
+    expect(town.metadata).toMatchObject({
+      position: [1, 2, 3],
+      name: "renamed",
+    });
   });
 
   it("keeps iterable metadata fields iterable through merges and motion", () => {

--- a/packages/core/src/core/entities.test.ts
+++ b/packages/core/src/core/entities.test.ts
@@ -49,7 +49,9 @@ function entityMessage(
   return {
     type: "ENTITY",
     tick: options.tick,
-    entities: [{ operation, id, type: "probe", metadata, motion: options.motion }],
+    entities: [
+      { operation, id, type: "probe", metadata, motion: options.motion },
+    ],
   } as MessageProtocol;
 }
 
@@ -237,6 +239,158 @@ describe("Entities compact motion path", () => {
     );
 
     expect(entities.getEntityById("ghost")).toBeUndefined();
+  });
+});
+
+describe("Entities resilience with Town-like consumers", () => {
+  // Town-style entity classes destructure/iterate metadata fields directly
+  // (`const [x, y, z] = data.position`), so handing them metadata missing
+  // those keys throws "x is not iterable" — the live staging breakage.
+  class DestructuringEntity extends Entity<ProbeData> {
+    public applied: [number, number, number][] = [];
+
+    onCreate = (data: ProbeData) => {
+      const [x, y, z] = data.position;
+      this.applied.push([x, y, z]);
+    };
+
+    onUpdate = (data: ProbeData) => {
+      const [x, y, z] = data.position;
+      this.applied.push([x, y, z]);
+    };
+  }
+
+  class ThrowingEntity extends Entity<ProbeData> {
+    onCreate = () => {
+      // A game-code bug: always throws on apply.
+      throw new Error("boom");
+    };
+
+    onUpdate = () => {
+      throw new Error("boom");
+    };
+  }
+
+  function makeTownEntities(): Entities {
+    const entities = new Entities();
+    entities.setClass("probe", ProbeEntity);
+    entities.setClass("town", DestructuringEntity);
+    entities.setClass("buggy", ThrowingEntity);
+    return entities;
+  }
+
+  it("never constructs an entity from a partial metadata-lane update", () => {
+    const entities = makeTownEntities();
+
+    // A compact metadata-lane payload (position stripped server-side)
+    // arrives for an entity whose CREATE this client never processed.
+    expect(() =>
+      entities.onMessage({
+        type: "ENTITY",
+        entities: [
+          {
+            operation: "UPDATE",
+            id: "ghost",
+            type: "town",
+            metadata: { name: "partial-only" },
+          },
+        ],
+      } as MessageProtocol),
+    ).not.toThrow();
+
+    expect(entities.getEntityById("ghost")).toBeUndefined();
+
+    // A full snapshot (carries position) still heals against old servers.
+    entities.onMessage({
+      type: "ENTITY",
+      entities: [
+        {
+          operation: "UPDATE",
+          id: "ghost",
+          type: "town",
+          metadata: { position: [1, 2, 3] },
+        },
+      ],
+    } as MessageProtocol);
+    const healed = entities.getEntityById("ghost") as DestructuringEntity;
+    expect(healed).toBeDefined();
+    expect(healed.applied).toContainEqual([1, 2, 3]);
+  });
+
+  it("isolates a throwing entity so the rest of the batch still applies", () => {
+    const entities = makeTownEntities();
+    entities.onMessage(
+      entityMessage("CREATE", "healthy", { position: [0, 0, 0] }),
+    );
+
+    // One message carrying a poisoned entity first, then a healthy update:
+    // the poison must not abort the batch (or escape the interceptor and
+    // stall everything queued behind the message).
+    expect(() =>
+      entities.onMessage({
+        type: "ENTITY",
+        entities: [
+          {
+            operation: "CREATE",
+            id: "bad",
+            type: "buggy",
+            metadata: { position: [1, 1, 1] },
+          },
+          {
+            operation: "UPDATE",
+            id: "healthy",
+            type: "probe",
+            metadata: { position: [9, 9, 9] },
+          },
+        ],
+      } as MessageProtocol),
+    ).not.toThrow();
+
+    const healthy = entities.getEntityById("healthy") as ProbeEntity;
+    expect(healthy.updateCount).toBe(1);
+    expect(healthy.metadata!.position).toEqual([9, 9, 9]);
+  });
+
+  it("keeps iterable metadata fields iterable through merges and motion", () => {
+    const entities = makeTownEntities();
+    entities.onMessage({
+      type: "ENTITY",
+      entities: [
+        {
+          operation: "CREATE",
+          id: "a",
+          type: "town",
+          metadata: {
+            position: [1, 2, 3],
+            path: {
+              nodes: [
+                [1, 1, 1],
+                [2, 2, 2],
+              ],
+            },
+          },
+        },
+      ],
+    } as MessageProtocol);
+
+    // Partial metadata update, then a motion-only update.
+    entities.onMessage(entityMessage("UPDATE", "a", { name: "renamed" }));
+    entities.onMessage(
+      entityMessage("UPDATE", "a", null, { motion: { position: [4, 5, 6] } }),
+    );
+
+    const town = entities.getEntityById("a") as DestructuringEntity;
+    const metadata = town.metadata as unknown as {
+      position: number[];
+      path: { nodes: number[][] };
+    };
+    expect(Array.isArray(metadata.position)).toBe(true);
+    expect(metadata.position).toEqual([4, 5, 6]);
+    expect(metadata.path.nodes).toEqual([
+      [1, 1, 1],
+      [2, 2, 2],
+    ]);
+    expect(town.applied).toContainEqual([4, 5, 6]);
   });
 });
 

--- a/packages/core/src/core/entities.ts
+++ b/packages/core/src/core/entities.ts
@@ -1,4 +1,9 @@
-import { EntityMotionProtocol, MessageProtocol } from "@voxelize/protocol";
+import {
+  EntityMotionProtocol,
+  EntityOperation,
+  EntityProtocol,
+  MessageProtocol,
+} from "@voxelize/protocol";
 import { Group, Vector3 } from "three";
 
 import { EntityLivenessTracker } from "./entity-liveness";
@@ -27,9 +32,7 @@ type MutableMetadata = { [key: string]: JsonValue };
 function isJsonObject(
   value: JsonValue | undefined,
 ): value is { [key: string]: JsonValue } {
-  return (
-    typeof value === "object" && value !== null && !Array.isArray(value)
-  );
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**
@@ -170,6 +173,8 @@ export class Entities extends Group implements NetIntercept {
 
   private unregisteredTypes = new Set<string>();
 
+  private erroredApplySignatures = new Set<string>();
+
   /**
    * Per-entity server tick of the last applied state, so out-of-order frames
    * on unordered transports (WebRTC) can never rewind an entity.
@@ -226,148 +231,183 @@ export class Entities extends Group implements NetIntercept {
     if (entities && entities.length) {
       const isLogging = isPerfLogging();
       const applyStartMs = isLogging ? performance.now() : 0;
-      try {
-        entities.forEach((entity) => {
-          const { id, type, metadata, operation, motion } = entity;
+      let failedCount = 0;
 
-          // ignore all block entities as they are handled by world
-          if (type.startsWith("block::")) {
-            return;
-          }
-
-          let object = this.map.get(id);
-
-          // The client half of the lifecycle ledger: every lifecycle
-          // operation that reaches this client is logged with the server's
-          // batch trace id, so end-to-end delivery (server queue -> client
-          // apply) is measurable per entity.
-          if (isLogging && operation !== "UPDATE") {
-            logPerf("entity_lifecycle_apply", {
+      entities.forEach((entity) => {
+        try {
+          this.applyEntityOperation(
+            entity,
+            messageTick,
+            nowSeconds,
+            isLogging,
+            message.perfTraceId ?? "",
+          );
+        } catch (error) {
+          // One faulty entity — a malformed payload or a throwing game
+          // callback — must never poison the rest of the batch: an aborted
+          // batch freezes every other entity in the message, and an error
+          // escaping this interceptor aborts everything queued behind the
+          // message (chunks included). Log, isolate, continue.
+          failedCount += 1;
+          const description =
+            error instanceof Error ? error.message : String(error);
+          if (isLogging) {
+            logPerf("entity_apply_error", {
               traceId: message.perfTraceId ?? "",
-              operation,
-              entityId: id,
-              entityType: type,
+              entityId: entity.id,
+              entityType: entity.type,
+              operation: entity.operation,
+              error: description,
             });
           }
-
-          switch (operation) {
-            case "CREATE": {
-              // CREATE always applies, no staleness check: it is the
-              // reliable, ordered, complete snapshot. A partial UPDATE that
-              // raced ahead on an unordered transport may have stamped a
-              // newer tick, but skipping the CREATE would leave the entity
-              // permanently incomplete; the watermark is monotonic, so
-              // applying the snapshot never lowers out-of-order protection.
-              if (object) {
-                // The server streams a fresh snapshot for an entity it believes
-                // is new to us, so resync our stale copy to it.
-                object.metadata = metadata;
-                object.onUpdate?.(metadata);
-                object.snapToTarget?.();
-                this.noteAppliedTick(id, messageTick);
-                this.liveness.touchEntity(id, nowSeconds);
-                return;
-              }
-
-              object = this.createEntityOfType(type, id);
-              if (object) {
-                object.metadata = metadata;
-                object.onCreate?.(metadata);
-                this.noteAppliedTick(id, messageTick);
-                this.liveness.touchEntity(id, nowSeconds);
-              }
-
-              break;
-            }
-            case "UPDATE": {
-              // A payload-less update is a keep-alive: the entity is unchanged
-              // but still streaming.
-              if (!metadata && !motion) {
-                if (object) {
-                  this.liveness.touchEntity(id, nowSeconds);
-                }
-                return;
-              }
-
-              // Out-of-order state (possible on unordered transports) must
-              // never rewind an entity — and must never resurrect one that a
-              // later lifecycle event already released.
-              if (this.isStaleFrame(id, messageTick)) {
-                return;
-              }
-
-              if (!object) {
-                // Only a metadata-bearing update carries enough state to
-                // construct an entity (a full legacy snapshot, or healing
-                // against a server that predates the compact motion path). A
-                // motion-only update waits for its reliable CREATE.
-                if (!metadata) {
-                  return;
-                }
-                object = this.createEntityOfType(type, id);
-                if (object) {
-                  object.metadata = metadata;
-                  object.onCreate?.(metadata);
-                }
-              }
-
-              if (object) {
-                // Merge instead of replace: compact-protocol servers send
-                // motion and non-motion state independently, and metadata
-                // keys are never removed server-side, so the accumulated map
-                // always presents the full legacy shape to game code.
-                const merged = mergeMetadataUpdate(
-                  object.metadata as MutableMetadata | null,
-                  metadata as MutableMetadata | null,
-                );
-                if (motion) {
-                  applyMotionToMetadata(merged, motion);
-                }
-                object.metadata = merged;
-                object.onUpdate?.(merged);
-                this.noteAppliedTick(id, messageTick);
-                this.liveness.touchEntity(id, nowSeconds);
-                if (
-                  isLogging &&
-                  (motion || (metadata && metadata.position !== undefined))
-                ) {
-                  this.recordMotionApplyGap(id);
-                }
-              }
-
-              break;
-            }
-            case "DELETE":
-            case "OUT_OF_RANGE": {
-              this.noteAppliedTick(id, messageTick);
-
-              if (!object) {
-                return;
-              }
-
-              this.releaseEntity(object, metadata ?? object.metadata);
-
-              break;
-            }
-          }
-        });
-      } catch (error) {
-        if (isLogging) {
-          logPerf("entity_apply_error", {
-            traceId: message.perfTraceId ?? "",
-            itemCount: entities.length,
-            error: error instanceof Error ? error.message : String(error),
-          });
+          this.reportApplyError(entity.type, entity.operation, error);
         }
-        throw error;
-      }
+      });
+
       if (isLogging) {
         logPerf("entity_apply", {
           traceId: message.perfTraceId ?? "",
           itemCount: entities.length,
+          failedCount,
           byteSize: message.perfByteSize ?? 0,
           durationMs: performance.now() - applyStartMs,
         });
+      }
+    }
+  };
+
+  private applyEntityOperation = (
+    entity: EntityProtocol<MutableMetadata | null>,
+    messageTick: number,
+    nowSeconds: number,
+    isLogging: boolean,
+    perfTraceId: string,
+  ) => {
+    const { id, type, metadata, operation, motion } = entity;
+
+    // ignore all block entities as they are handled by world
+    if (type.startsWith("block::")) {
+      return;
+    }
+
+    let object = this.map.get(id);
+
+    // The client half of the lifecycle ledger: every lifecycle
+    // operation that reaches this client is logged with the server's
+    // batch trace id, so end-to-end delivery (server queue -> client
+    // apply) is measurable per entity.
+    if (isLogging && operation !== "UPDATE") {
+      logPerf("entity_lifecycle_apply", {
+        traceId: perfTraceId,
+        operation,
+        entityId: id,
+        entityType: type,
+      });
+    }
+
+    switch (operation) {
+      case "CREATE": {
+        // CREATE always applies, no staleness check: it is the
+        // reliable, ordered, complete snapshot. A partial UPDATE that
+        // raced ahead on an unordered transport may have stamped a
+        // newer tick, but skipping the CREATE would leave the entity
+        // permanently incomplete; the watermark is monotonic, so
+        // applying the snapshot never lowers out-of-order protection.
+        if (object) {
+          // The server streams a fresh snapshot for an entity it believes
+          // is new to us, so resync our stale copy to it.
+          object.metadata = metadata;
+          object.onUpdate?.(metadata);
+          object.snapToTarget?.();
+          this.noteAppliedTick(id, messageTick);
+          this.liveness.touchEntity(id, nowSeconds);
+          return;
+        }
+
+        object = this.createEntityOfType(type, id);
+        if (object) {
+          object.metadata = metadata;
+          object.onCreate?.(metadata);
+          this.noteAppliedTick(id, messageTick);
+          this.liveness.touchEntity(id, nowSeconds);
+        }
+
+        break;
+      }
+      case "UPDATE": {
+        // A payload-less update is a keep-alive: the entity is unchanged
+        // but still streaming.
+        if (!metadata && !motion) {
+          if (object) {
+            this.liveness.touchEntity(id, nowSeconds);
+          }
+          return;
+        }
+
+        // Out-of-order state (possible on unordered transports) must
+        // never rewind an entity — and must never resurrect one that a
+        // later lifecycle event already released.
+        if (this.isStaleFrame(id, messageTick)) {
+          return;
+        }
+
+        if (!object) {
+          // Only a COMPLETE snapshot may construct an entity. Full
+          // snapshots (legacy servers, old-server healing) always
+          // carry the engine-written `position`; compact
+          // metadata-lane payloads are partial projections and never
+          // do. Constructing from a partial snapshot hands game
+          // callbacks metadata missing the keys they iterate
+          // (position, direction, ...) — the exact shape that broke
+          // Town staging. Partial state waits for the reliable
+          // CREATE.
+          if (!metadata || metadata.position === undefined) {
+            return;
+          }
+          object = this.createEntityOfType(type, id);
+          if (object) {
+            object.metadata = metadata;
+            object.onCreate?.(metadata);
+          }
+        }
+
+        if (object) {
+          // Merge instead of replace: compact-protocol servers send
+          // motion and non-motion state independently, and metadata
+          // keys are never removed server-side, so the accumulated map
+          // always presents the full legacy shape to game code.
+          const merged = mergeMetadataUpdate(
+            object.metadata as MutableMetadata | null,
+            metadata as MutableMetadata | null,
+          );
+          if (motion) {
+            applyMotionToMetadata(merged, motion);
+          }
+          object.metadata = merged;
+          object.onUpdate?.(merged);
+          this.noteAppliedTick(id, messageTick);
+          this.liveness.touchEntity(id, nowSeconds);
+          if (
+            isLogging &&
+            (motion || (metadata && metadata.position !== undefined))
+          ) {
+            this.recordMotionApplyGap(id);
+          }
+        }
+
+        break;
+      }
+      case "DELETE":
+      case "OUT_OF_RANGE": {
+        this.noteAppliedTick(id, messageTick);
+
+        if (!object) {
+          return;
+        }
+
+        this.releaseEntity(object, metadata ?? object.metadata);
+
+        break;
       }
     }
   };
@@ -434,6 +474,28 @@ export class Entities extends Group implements NetIntercept {
       this.releaseEntity(object, object.metadata);
     }
     this.lastAppliedTick.clear();
+  };
+
+  /**
+   * Console-reports an entity apply failure once per (type, operation)
+   * signature. Streaming entities re-send continuously, so an unthrottled
+   * report would flood the console at tick rate while adding nothing.
+   */
+  private reportApplyError = (
+    entityType: string,
+    operation: EntityOperation,
+    error: Error | string | number | boolean | null | undefined,
+  ) => {
+    const signature = `${entityType}:${operation}`;
+    if (this.erroredApplySignatures.has(signature)) {
+      return;
+    }
+    this.erroredApplySignatures.add(signature);
+    console.error(
+      `[entities] Applying a "${operation}" for entity type "${entityType}" failed; ` +
+        `further errors for this type and operation are suppressed.`,
+      error,
+    );
   };
 
   private isStaleFrame = (id: string, messageTick: number) => {

--- a/packages/core/src/core/network/workers/decode-utils.test.ts
+++ b/packages/core/src/core/network/workers/decode-utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { decodeMotion } from "./decode-utils";
+import {
+  coerceMotionBytes,
+  decodeMotion,
+  normalizeEntityMotion,
+} from "./decode-utils";
 
 const FLAG_IN_FLUID = 1 << 0;
 const FLAG_HAS_DIRECTION = 1 << 1;
@@ -98,5 +102,80 @@ describe("decodeMotion", () => {
       targetPosition: [4, 5, 6],
     }).subarray(0, 20);
     expect(decodeMotion(truncatedTarget)).toBeUndefined();
+  });
+});
+
+describe("coerceMotionBytes", () => {
+  it("accepts any ArrayBufferView, ArrayBuffer, or plain byte array", () => {
+    const payload = encodeMotion({ position: [1, 2, 3] });
+
+    expect(coerceMotionBytes(payload)).toBe(payload);
+
+    // A different view type over the same bytes, at a nonzero offset.
+    const padded = new Uint8Array(payload.length + 4);
+    padded.set(payload, 4);
+    const view = new DataView(padded.buffer, 4, payload.length);
+    expect(Array.from(coerceMotionBytes(view) ?? [])).toEqual(
+      Array.from(payload),
+    );
+
+    const copy = payload.buffer.slice(
+      payload.byteOffset,
+      payload.byteOffset + payload.byteLength,
+    ) as ArrayBuffer;
+    expect(Array.from(coerceMotionBytes(copy) ?? [])).toEqual(
+      Array.from(payload),
+    );
+
+    expect(Array.from(coerceMotionBytes(Array.from(payload)) ?? [])).toEqual(
+      Array.from(payload),
+    );
+  });
+
+  it("returns null for non-byte-like values", () => {
+    expect(coerceMotionBytes(null)).toBeNull();
+    expect(coerceMotionBytes(undefined)).toBeNull();
+  });
+});
+
+describe("normalizeEntityMotion", () => {
+  it("decodes motion delivered as a non-Uint8Array view", () => {
+    const payload = encodeMotion({ position: [4, 5, 6] });
+    const entity: Record<string, unknown> = {
+      motion: new DataView(
+        payload.buffer,
+        payload.byteOffset,
+        payload.byteLength,
+      ),
+    };
+
+    normalizeEntityMotion(entity);
+
+    expect(entity.motion).toMatchObject({ position: [4, 5, 6] });
+  });
+
+  it("fails safe on undecodable motion so no update applies a missing position", () => {
+    const corrupt = encodeMotion({ position: [1, 2, 3] });
+    corrupt[0] = 99;
+    const entity: Record<string, unknown> = {
+      motion: corrupt,
+      metadata: { name: "keeper" },
+    };
+
+    normalizeEntityMotion(entity);
+
+    // The motion field is removed outright — the update degrades to its
+    // metadata (or a keep-alive), never an apply with a half-decoded or
+    // absent position.
+    expect("motion" in entity).toBe(false);
+    expect(entity.metadata).toEqual({ name: "keeper" });
+
+    const empty: Record<string, unknown> = { motion: new Uint8Array(0) };
+    normalizeEntityMotion(empty);
+    expect("motion" in empty).toBe(false);
+
+    const absent: Record<string, unknown> = {};
+    normalizeEntityMotion(absent);
+    expect("motion" in absent).toBe(false);
   });
 });

--- a/packages/core/src/core/network/workers/decode-utils.ts
+++ b/packages/core/src/core/network/workers/decode-utils.ts
@@ -107,6 +107,55 @@ type DecodedMotion = {
   targetPosition?: [number, number, number];
 };
 
+type MotionBytesLike =
+  | Uint8Array
+  | ArrayBufferView
+  | ArrayBuffer
+  | number[]
+  | null
+  | undefined;
+
+/**
+ * Coerce whatever byte container the protobuf runtime hands us into a
+ * Uint8Array. Depending on the environment (worker realms, Node Buffers,
+ * JSON round-trips) the `motion` field may arrive as a different
+ * ArrayBufferView, a raw ArrayBuffer, or a plain byte array — an
+ * `instanceof Uint8Array` check silently drops all of those, which would
+ * leave a compact-protocol client without any position stream.
+ */
+export function coerceMotionBytes(value: MotionBytesLike): Uint8Array | null {
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+  if (Array.isArray(value)) {
+    return Uint8Array.from(value);
+  }
+  return null;
+}
+
+/**
+ * Normalize an entity's wire `motion` field in place: coerce the byte
+ * container, decode it, and FAIL SAFE — when the payload is absent, empty,
+ * or undecodable, the field is removed entirely so the update degrades to
+ * its metadata (or a keep-alive), never to an apply with a half-decoded or
+ * missing position.
+ */
+export function normalizeEntityMotion(entity: Record<string, unknown>): void {
+  const bytes = coerceMotionBytes(entity.motion as MotionBytesLike);
+  const decoded = bytes && bytes.length > 0 ? decodeMotion(bytes) : undefined;
+  if (decoded) {
+    entity.motion = decoded;
+  } else {
+    delete entity.motion;
+  }
+}
+
 /**
  * Decode a versioned compact motion payload (kept in byte-for-byte sync with
  * `server/world/replication/motion.rs`). Returns undefined for unknown
@@ -204,11 +253,7 @@ export function decodeMessage(
           parsed.json = deepParseJSON(parsed.json);
         }
       }
-      if (entity.motion instanceof Uint8Array && entity.motion.length > 0) {
-        entity.motion = decodeMotion(entity.motion);
-      } else {
-        delete entity.motion;
-      }
+      normalizeEntityMotion(entity);
       entity.operation = Entity.Operation[entity.operation as number];
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Fix the Town staging live break on the #114 pin (`entity_apply_error: "t is not iterable"`)

Unblocks Town re-pinning to Voxelize main. Town stays on `c4cc76961` until Rivet clears this; no Town-side adapter is required (the optional Town-side `Array.isArray(data?.position)` no-op guard remains a belt-and-suspenders option, not a requirement).

**Tip `41cb7ab41`** — includes the Rivet-requested decode hardenings on top of `8382a2909`.

## Root cause (two compounding client bugs in `packages/core/src/core/entities.ts`)

1. **Partial-snapshot construction.** With the compact `motion.v1` path negotiated, metadata-lane UPDATEs carry only the non-motion projection of an entity's metadata (no `position` — it rides the motion lane). If such an UPDATE arrived for an entity the client wasn't tracking (e.g. its CREATE batch was shed from the inbound packet queue during a join-time chunk flood, or unordered-transport reordering), the client CONSTRUCTED the entity from that partial projection and called `onCreate`/`onUpdate` with metadata missing `position`. Town entity classes destructure it (`const [x, y, z] = data.position`) → `"t is not iterable (cannot read property undefined)"`.
2. **Batch poisoning.** The apply loop wrapped the WHOLE batch in one try/catch that logged `entity_apply_error` and **rethrew**. One faulty entity therefore aborted every other entity in the message (the continuous errors at `itemCount ~50–64` — exactly one flush batch), and the escaping exception aborted the rest of the decoded packet batch in `Network.sync`, stalling chunk LOAD processing behind it — which is why #94 acceptance also failed on `waitFor` chunk timeouts.

## Fixes

- **UPDATEs never construct entities from partial snapshots** (`8382a2909`). Only a snapshot carrying the engine-written `position` key qualifies (full legacy snapshots and old-server healing always have it; compact metadata-lane projections never do). Partial state waits for the reliable CREATE — which the #114 server re-sends on rejoin, and lifecycle keep-alive/staleness heals.
- **Per-entity apply isolation** (`8382a2909`). Each entity's apply runs in its own try/catch: failures log `entity_apply_error` with `entityId`/`entityType`/`operation`/`error` (plus a `failedCount` on the `entity_apply` summary event) and a per-(type, operation) deduped `console.error`. Nothing rethrows out of the interceptor, so one buggy entity or payload can never freeze the batch, other intercepts, or queued chunk messages.
- **Motion byte-container coercion** (`41cb7ab41`, `decode-utils.ts`). `coerceMotionBytes` accepts any `ArrayBufferView` (including Node Buffers and views at nonzero offsets), raw `ArrayBuffer`, or plain byte array — replacing the realm-fragile `instanceof Uint8Array` check that would silently drop every motion payload delivered in another container shape and freeze compact clients.
- **Fail-safe on undecodable motion** (`41cb7ab41`). `normalizeEntityMotion` removes the motion field outright when the payload is absent, empty, or fails `decodeMotion` (unknown version, truncation), so the update degrades to its metadata or a keep-alive. Combined with the construct guard and merge semantics, an UPDATE carrying neither `metadata.position` nor usable motion never applies and never hands game code a missing/half-decoded position.

## Regression tests

`entities.test.ts` ("Entities resilience with Town-like consumers") — written against Town-like consumer shapes (a class that destructures `data.position`, a class whose callbacks throw):

- `never constructs an entity from a partial metadata-lane update` — reproduces the exact staging shape; fails on the old code with "not iterable"; verifies full-snapshot healing still works.
- `isolates a throwing entity so the rest of the batch still applies` — poisoned entity first in the batch; healthy entity after it still applies; nothing escapes `onMessage`.
- `degrades an update whose motion failed to decode without ever losing position` — stripped-motion keep-alive applies nothing; stripped-motion + partial metadata merges without ever exposing an undefined position.
- `keeps iterable metadata fields iterable through merges and motion` — arrays (`position`, nested `path.nodes`) stay arrays through partial merges and motion application.

`decode-utils.test.ts`:

- `coerceMotionBytes` accepts Uint8Array / DataView-at-offset / ArrayBuffer / number[] and rejects non-byte-likes.
- `normalizeEntityMotion` decodes motion delivered as a non-Uint8Array view, and fails safe (field removed, metadata untouched) on corrupt, empty, and absent payloads.

## Checks (at `41cb7ab41`)

- `pnpm test` (vitest) — 112 passed (19 in `entities.test.ts`, 6 in `decode-utils.test.ts`; all prior Rivet blocker regressions still green)
- `npx tsc --noEmit -p packages/core/tsconfig.json` — clean
- `npx eslint` on touched files — 0 errors (remaining warnings are the files' pre-existing non-null-assertion style)

No server/protocol changes; client-only hardening on top of `4022391bb`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b747625-f72f-4653-ad4f-c9bb083337ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b747625-f72f-4653-ad4f-c9bb083337ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

