### PR TITLE
fix(protocol): regenerate Entity.decode so motion field 5 is not skipped

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -16,16 +16,17 @@
   "scripts": {
     "watch": "cross-env NODE_ENV=development npm-run-all --parallel \"compile -w\" \"types -w --preserveWatchOutput\"",
     "clean": "rimraf ./dist ./tsconfig.tsbuildinfo",
-    "test": "pnpm vitest",
+    "test": "pnpm vitest run",
     "compile": "vite build",
-    "build": "pnpm run clean && pnpm run compile && pnpm run types && pnpm run copyproto",
+    "build": "pnpm run proto && pnpm run clean && pnpm run compile && pnpm run types && pnpm run copyproto",
     "types": "tsc --emitDeclarationOnly --outDir ./dist -p ./tsconfig.json --declaration",
     "copyproto": "cp ./src/protocol.* ./dist",
     "prepublishOnly": "pnpm run build",
     "proto:ts": "pbts -o ./src/protocol.d.ts ./src/protocol.js",
     "proto:js": "pbjs -t static-module --dependency protobufjs/minimal.js -w es6 -o ./src/protocol.js ../../messages.proto",
     "proto": "pnpm run proto:js && pnpm run proto:ts && mkdirp dist && cp src/protocol.* dist/",
-    "preinstall": "npx only-allow pnpm"
+    "preinstall": "npx only-allow pnpm",
+    "pretest": "pnpm run proto"
   },
   "dependencies": {
     "protobufjs": "^7.4.0",

--- a/packages/protocol/src/entity-motion-codegen.test.ts
+++ b/packages/protocol/src/entity-motion-codegen.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { protocol } from "./index";
+
+const { Entity } = protocol;
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe("Entity protobuf codegen (motion = 5)", () => {
+  it("generated Entity.decode handles field 5 as bytes motion", () => {
+    const generated = readFileSync(join(here, "protocol.js"), "utf8");
+    expect(generated).toMatch(/Entity\.decode\s*=\s*function/);
+    // Stale codegen from before messages.proto gained `optional bytes motion = 5`
+    // falls through to skipType and never materializes entity.motion — which
+    // freezes compact motion.v1 clients while legacy metadata.position still moves.
+    expect(generated).toMatch(
+      /case\s+5:\s*\{\s*message\.motion\s*=\s*reader\.bytes\(\);/,
+    );
+  });
+
+  it("round-trips optional motion bytes through Entity.encode/decode", () => {
+    const motion = Uint8Array.from([1, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4]);
+    const encoded = Entity.encode(
+      Entity.create({
+        operation: Entity.Operation.UPDATE,
+        id: "fauna-1",
+        type: "fauna",
+        metadata: "",
+        motion,
+      }),
+    ).finish();
+
+    const decoded = Entity.decode(encoded);
+    expect(decoded.operation).toBe(Entity.Operation.UPDATE);
+    expect(decoded.id).toBe("fauna-1");
+    expect(decoded.type).toBe("fauna");
+    expect(decoded.motion).toBeInstanceOf(Uint8Array);
+    expect(Array.from(decoded.motion as Uint8Array)).toEqual(Array.from(motion));
+  });
+
+  it("omits motion when absent so legacy clients stay on metadata.position", () => {
+    const encoded = Entity.encode(
+      Entity.create({
+        operation: Entity.Operation.UPDATE,
+        id: "legacy-1",
+        type: "fauna",
+        metadata: "{\"position\":[1,2,3]}",
+      }),
+    ).finish();
+    const decoded = Entity.decode(encoded);
+    expect(decoded.motion == null || decoded.motion.length === 0).toBe(true);
+    expect(decoded.metadata).toContain("position");
+  });
+});


### PR DESCRIPTION
## Summary
- Root cause of frozen fauna on Town staging: gitignored `@voxelize/protocol` `Entity.decode` only handled fields 1–4, so protobuf field 5 (`optional bytes motion`) hit `skipType`.
- Compact `motion.v1` clients never materialized `motion`; legacy clients still moved via `metadata.position`.
- Hook `pnpm proto` into `@voxelize/protocol` `build` + `pretest`, and add a codegen/round-trip regression test that fails if field 5 is omitted again.

## Test plan
- [x] `pnpm --dir packages/protocol proto` regenerates `case 5: message.motion = reader.bytes()`
- [x] `pnpm --dir packages/protocol test` (3/3) including encode/decode round-trip of motion bytes
- [ ] Town staging: rebuild client against this tip; compact client sees `motion` after decode and fauna positions change; legacy still moves

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and test-only changes in the protocol package; fixes client motion decoding without touching auth or server data paths.
> 
> **Overview**
> Fixes **stale protobuf codegen** in `@voxelize/protocol` where `Entity.decode` only handled fields 1–4, so protobuf **field 5 (`optional bytes motion`)** was skipped and compact `motion.v1` clients saw frozen fauna while legacy clients still moved via `metadata.position`.
> 
> **Build/test pipeline:** `build` now runs **`pnpm proto`** before clean/compile so generated `protocol.js` matches `messages.proto`. **`pretest`** also runs proto; tests use **`vitest run`** instead of watch mode.
> 
> **Regression coverage:** New tests assert generated decode includes `case 5: message.motion = reader.bytes()`, round-trip motion bytes through encode/decode, and that entities without motion omit the field for legacy compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19458e52fad63cb3ccfd62f72ded25bac23cb97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->