### PR TITLE
fix(protocol): regenerate pbjs output during package build

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,7 +18,7 @@
     "clean": "rimraf ./dist ./tsconfig.tsbuildinfo",
     "test": "pnpm vitest",
     "compile": "vite build",
-    "build": "pnpm run clean && pnpm run compile && pnpm run types && pnpm run copyproto",
+    "build": "pnpm run proto && pnpm run clean && pnpm run compile && pnpm run types && pnpm run copyproto",
     "types": "tsc --emitDeclarationOnly --outDir ./dist -p ./tsconfig.json --declaration",
     "copyproto": "cp ./src/protocol.* ./dist",
     "prepublishOnly": "pnpm run build",


### PR DESCRIPTION
## Summary
- Root cause of Rivet CODE SHIP freeze: `packages/protocol/src/protocol.js` is gitignored and was never regenerated after `optional bytes motion = 5` landed in `messages.proto`, so `Entity.decode` only handled fields 1–4 and skipped compact motion.
- Run `pnpm proto` (pbjs/pbts on `messages.proto`) as the first step of `@voxelize/protocol` `build`, so encode/decode always include `motion`.

## Test plan
- [x] `pnpm --dir packages/protocol proto:js` produces `Entity.decode` `case 5: message.motion = reader.bytes()`
- [ ] Staging client rebuild embeds regenerated protocol
- [ ] A/B: compact `motion.v1` → motion present + fauna positions advance; legacy no-cap still moves; `entity_apply_error` = 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-script ordering change; ensures generated protocol artifacts stay in sync with the proto schema.
> 
> **Overview**
> **Fixes client freezes when the server sends compact entity `motion`:** generated protobuf JS was stale because `protocol.js` is not committed and `build` never ran `pnpm proto` after `messages.proto` gained field 5.
> 
> The `@voxelize/protocol` **`build` script now runs `proto` first** (pbjs/pbts from `messages.proto`, then copy into `dist/`) before `clean`, compile, types, and `copyproto`, so every package build refreshes `Entity` encode/decode including **`motion`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200122dea10c142f97b9e8c8933d88c9e5d64582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->