### PR TITLE
fix(protocol): exclude codegen tests from declaration emit

### DIFF
--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "../../tsconfig.build.json",
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ],
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- After #116, `entity-motion-codegen.test.ts` is under `src/` and `tsc --declaration` fails on `import.meta`, aborting `@voxelize/protocol` build before `copyproto`.
- Exclude `src/**/*.test.ts` from the package tsconfig so vitest still runs the field-5 regression while `pnpm build` succeeds.

## Test plan
- [x] `pnpm --dir packages/protocol build` completes and `dist/protocol.js` has `message.motion = reader.bytes()`
- [ ] Staging `node scripts/staging-stack.mjs build` + deploy-client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/tsconfig-only change; no runtime or API surface impact.
> 
> **Overview**
> **Fixes `@voxelize/protocol` builds** after test files were moved under `src/`: `tsc` with `declaration` no longer compiles `src/**/*.test.ts`, so codegen tests (e.g. `import.meta`) cannot abort the build before `copyproto`.
> 
> `packages/protocol/tsconfig.json` adds an **`exclude` for `src/**/*.test.ts`** and reformats `include`; behavior for shipped sources is unchanged. **Vitest** still picks up those tests independently of the package tsconfig.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d3d37879b5870b8e3e16037fedf48597d6b7986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->