### PR TITLE
feat(world): subchunk random-tick sampler + earliest-deadline active upsert

### DIFF
--- a/server/world/config.rs
+++ b/server/world/config.rs
@@ -46,6 +46,20 @@ pub struct WorldConfig {
     /// Maximum voxel updates to be processed per tick. Default is 1000 voxels.
     pub max_updates_per_tick: usize,
 
+    /// Minecraft-style random tick speed: each loaded/interested 16x16x(section)
+    /// subchunk samples this many random positions per world tick and, if the
+    /// block is `is_random_tickable`, schedules its `active_updater` at the
+    /// current tick. Default is 3 (Minecraft's `randomTickSpeed` default).
+    /// Set to 0 to disable the sampler entirely.
+    pub random_tick_speed: usize,
+
+    /// Hard cap on how many random-tick samples may be taken across all
+    /// interested subchunks in a single world tick. Keeps the sampler from
+    /// starving the neighbor/scheduled active queue (copper). Default 2048.
+    /// Priority: scheduled `active_voxel_heap` work always runs first in
+    /// `ChunkUpdatingSystem`; the sampler only *queues* work for later pops.
+    pub max_random_ticks_per_tick: usize,
+
     /// Maximum responses to send to client per tick to prevent bottle-necking. Default is 4 chunks.
     pub max_response_per_tick: usize,
 
@@ -183,6 +197,9 @@ const DEFAULT_MAX_HEIGHT: usize = 256;
 const DEFAULT_MAX_LIGHT_LEVEL: u32 = 15;
 const DEFAULT_MAX_CHUNKS_PER_TICK: usize = 4;
 const DEFAULT_MAX_UPDATES_PER_TICK: usize = 50000;
+/// Minecraft default `gamerule randomTickSpeed` = 3 samples per 16^3 section.
+const DEFAULT_RANDOM_TICK_SPEED: usize = 3;
+const DEFAULT_MAX_RANDOM_TICKS_PER_TICK: usize = 2048;
 const DEFAULT_MAX_RESPONSE_PER_TICK: usize = 4;
 const DEFAULT_MAX_SAVES_PER_TICK: usize = 2;
 const DEFAULT_TICKS_PER_DAY: u64 = 24000;
@@ -223,6 +240,8 @@ pub struct WorldConfigBuilder {
     max_light_level: u32,
     max_chunks_per_tick: usize,
     max_updates_per_tick: usize,
+    random_tick_speed: usize,
+    max_random_ticks_per_tick: usize,
     max_response_per_tick: usize,
     max_saves_per_tick: usize,
     time_per_day: u64,
@@ -271,6 +290,8 @@ impl WorldConfigBuilder {
             max_light_level: DEFAULT_MAX_LIGHT_LEVEL,
             max_chunks_per_tick: DEFAULT_MAX_CHUNKS_PER_TICK,
             max_updates_per_tick: DEFAULT_MAX_UPDATES_PER_TICK,
+            random_tick_speed: DEFAULT_RANDOM_TICK_SPEED,
+            max_random_ticks_per_tick: DEFAULT_MAX_RANDOM_TICKS_PER_TICK,
             max_response_per_tick: DEFAULT_MAX_RESPONSE_PER_TICK,
             max_saves_per_tick: DEFAULT_MAX_SAVES_PER_TICK,
             time_per_day: DEFAULT_TICKS_PER_DAY,
@@ -375,6 +396,21 @@ impl WorldConfigBuilder {
     /// Configure the maximum amount of voxel updates to be processed per tick. Default is 1000 voxel updates.
     pub fn max_updates_per_tick(mut self, max_updates_per_tick: usize) -> Self {
         self.max_updates_per_tick = max_updates_per_tick;
+        self
+    }
+
+    /// Minecraft-style random tick speed (samples per loaded subchunk section
+    /// per world tick). Default 3. Set 0 to disable.
+    pub fn random_tick_speed(mut self, random_tick_speed: usize) -> Self {
+        self.random_tick_speed = random_tick_speed;
+        self
+    }
+
+    /// Cap on total random-tick samples across all interested subchunks per
+    /// world tick. Default 2048. Scheduled active-queue work is not counted
+    /// against this budget and always runs first.
+    pub fn max_random_ticks_per_tick(mut self, max_random_ticks_per_tick: usize) -> Self {
+        self.max_random_ticks_per_tick = max_random_ticks_per_tick;
         self
     }
 
@@ -573,6 +609,8 @@ impl WorldConfigBuilder {
             max_light_level: self.max_light_level,
             max_chunks_per_tick: self.max_chunks_per_tick,
             max_updates_per_tick: self.max_updates_per_tick,
+            random_tick_speed: self.random_tick_speed,
+            max_random_ticks_per_tick: self.max_random_ticks_per_tick,
             max_response_per_tick: self.max_response_per_tick,
             max_saves_per_tick: self.max_saves_per_tick,
             time_per_day: self.time_per_day,

--- a/server/world/systems/chunk/mod.rs
+++ b/server/world/systems/chunk/mod.rs
@@ -3,6 +3,7 @@ mod generating;
 mod requests;
 mod saving;
 mod sending;
+mod random_tick;
 mod updating;
 
 pub use current::CurrentChunkSystem;
@@ -10,4 +11,5 @@ pub use generating::ChunkGeneratingSystem;
 pub use requests::ChunkRequestsSystem;
 pub use saving::ChunkSavingSystem;
 pub use sending::ChunkSendingSystem;
+pub use random_tick::sample_random_ticks;
 pub use updating::ChunkUpdatingSystem;

--- a/server/world/systems/chunk/random_tick.rs
+++ b/server/world/systems/chunk/random_tick.rs
@@ -1,0 +1,305 @@
+//! Minecraft-style subchunk random-tick sampler.
+//!
+//! Each world tick, for every **loaded + interested** chunk that is `Ready`,
+//! each 16x16x(section_height) subchunk section samples
+//! [`WorldConfig::random_tick_speed`] random positions (MC default: 3).
+//! If the block at that position is `is_random_tickable` and has an
+//! `active_updater`, it is scheduled via [`Chunks::mark_voxel_active`] at the
+//! **current tick** (earliest-deadline upsert) so the existing active queue
+//! runs the updater -- no Town-side full plant scan.
+//!
+//! Budget: total samples across all sections in one tick are capped by
+//! [`WorldConfig::max_random_ticks_per_tick`]. The scheduled
+//! `active_voxel_heap` always runs in `ChunkUpdatingSystem` independently;
+//! this sampler only *enqueues* work and cannot starve copper neighbor updates.
+//!
+//! Sampling is deterministic given `(seed, tick, chunk_x, chunk_z, section)`.
+
+use crate::{ChunkInterests, ChunkStatus, Chunks, Registry, Vec2, Vec3, VoxelAccess, WorldConfig};
+
+/// Run one random-tick pass. Returns how many samples were taken (not how
+/// many blocks actually opted in / were marked active).
+pub fn sample_random_ticks(
+    chunks: &mut Chunks,
+    registry: &Registry,
+    interests: &ChunkInterests,
+    config: &WorldConfig,
+    current_tick: u64,
+) -> usize {
+    let speed = config.random_tick_speed;
+    if speed == 0 {
+        return 0;
+    }
+
+    let budget = config.max_random_ticks_per_tick;
+    if budget == 0 {
+        return 0;
+    }
+
+    let chunk_size = config.chunk_size;
+    let max_height = config.max_height;
+    let sub_chunks = config.sub_chunks.max(1);
+    let section_height = max_height / sub_chunks;
+    if section_height == 0 || chunk_size == 0 {
+        return 0;
+    }
+
+    let seed = config.seed;
+    let mut samples_taken = 0usize;
+
+    // Snapshot interested coords so we do not hold a borrow across mutation.
+    let interested: Vec<Vec2<i32>> = interests.map.keys().cloned().collect();
+
+    for coords in interested {
+        if samples_taken >= budget {
+            break;
+        }
+        if !chunks.is_chunk_ready(&coords) {
+            continue;
+        }
+        // Confirm still Ready (is_chunk_ready already checks) and present.
+        let Some(chunk) = chunks.raw(&coords) else {
+            continue;
+        };
+        if chunk.status != ChunkStatus::Ready {
+            continue;
+        }
+
+        let min = chunk.min.clone();
+        // Drop chunk borrow before mark_voxel_active.
+        drop(chunk);
+
+        for section in 0..sub_chunks {
+            if samples_taken >= budget {
+                break;
+            }
+            let remaining = budget - samples_taken;
+            let n = speed.min(remaining);
+            for i in 0..n {
+                let (lx, ly_local, lz) =
+                    sample_position(seed, current_tick, coords.0, coords.1, section as u32, i as u32, chunk_size, section_height);
+                let vx = min.0 + lx as i32;
+                let vy = (section * section_height + ly_local) as i32;
+                let vz = min.2 + lz as i32;
+
+                samples_taken += 1;
+
+                let id = chunks.get_voxel(vx, vy, vz);
+                if id == 0 {
+                    continue;
+                }
+                let block = registry.get_block_by_id(id);
+                if !block.is_random_tickable || !block.is_active {
+                    continue;
+                }
+                // Schedule at current tick so the same ChunkUpdatingSystem pass
+                // (or the next pop) can run the updater. Earliest-deadline
+                // upsert means a copper neighbor wake still wins if sooner.
+                chunks.mark_voxel_active(&Vec3(vx, vy, vz), current_tick);
+            }
+        }
+    }
+
+    samples_taken
+}
+
+/// Deterministic local position inside a section.
+/// Returns (local_x, local_y_in_section, local_z).
+pub fn sample_position(
+    seed: u32,
+    tick: u64,
+    cx: i32,
+    cz: i32,
+    section: u32,
+    sample_index: u32,
+    chunk_size: usize,
+    section_height: usize,
+) -> (usize, usize, usize) {
+    // SplitMix64-ish mix; stable across platforms (no HashMap iteration).
+    let mut state = mix64(
+        seed as u64
+            ^ tick.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            ^ ((cx as u64).wrapping_mul(0xC2B2_AE3D_27D4_EB4F))
+            ^ ((cz as u64).wrapping_mul(0x1656_67B1_9E37_79F9))
+            ^ ((section as u64) << 32)
+            ^ (sample_index as u64).wrapping_mul(0x85EB_CA77_C2B2_AE63),
+    );
+    let x = (state as usize) % chunk_size;
+    state = mix64(state);
+    let y = (state as usize) % section_height;
+    state = mix64(state);
+    let z = (state as usize) % chunk_size;
+    let _ = state;
+    (x, y, z)
+}
+
+fn mix64(mut z: u64) -> u64 {
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Block, BlockUtils, Chunk, ChunkOptions, WorldConfig};
+
+    fn ready_chunk(cx: i32, cz: i32, size: usize, max_height: usize, sub_chunks: usize) -> Chunk {
+        let mut chunk = Chunk::new(
+            "test",
+            cx,
+            cz,
+            &ChunkOptions {
+                size,
+                max_height,
+                sub_chunks,
+            },
+        );
+        chunk.status = ChunkStatus::Ready;
+        chunk
+    }
+
+    fn growth_block(id: u32) -> Block {
+        Block::new("Test Crop")
+            .id(id)
+            .is_plant(true)
+            .is_random_tickable(true)
+            .active_fn(
+                |_, _, _| 0,
+                move |voxel, _, _| {
+                    // Bump stage bit via raw rewrite marker: set id+0 stays,
+                    // return a no-op-looking update that tests can observe by
+                    // checking mark_voxel_active was called (deadline set).
+                    let _ = voxel;
+                    vec![]
+                },
+            )
+            .build()
+    }
+
+    #[test]
+    fn sample_position_is_deterministic() {
+        let a = sample_position(123, 10, 0, 0, 0, 0, 16, 16);
+        let b = sample_position(123, 10, 0, 0, 0, 0, 16, 16);
+        assert_eq!(a, b);
+        let c = sample_position(123, 11, 0, 0, 0, 0, 16, 16);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn random_tick_marks_opt_in_block_in_interested_ready_chunk() {
+        let config = WorldConfig::new()
+            .chunk_size(16)
+            .max_height(16)
+            .sub_chunks(1)
+            .random_tick_speed(16 * 16 * 16) // sample entire section eventually within budget
+            .max_random_ticks_per_tick(16 * 16 * 16)
+            .seed(1)
+            .build();
+
+        let mut registry = Registry::new();
+        let crop = growth_block(42);
+        registry.register_block(&crop);
+
+        let mut chunks = Chunks::new(&config);
+        let mut chunk = ready_chunk(0, 0, 16, 16, 1);
+        // Place crop at a known local cell; with full-section sampling it will
+        // be hit within one pass when speed == volume.
+        let vx = 3;
+        let vy = 4;
+        let vz = 5;
+        let raw = BlockUtils::insert_id(0, 42);
+        assert!(chunk.set_raw_voxel(vx, vy, vz, raw));
+        chunks.add(chunk);
+
+        let mut interests = ChunkInterests::new();
+        interests.add("tester", &Vec2(0, 0));
+
+        let taken = sample_random_ticks(&mut chunks, &registry, &interests, &config, 7);
+        assert_eq!(taken, 16 * 16 * 16);
+        assert_eq!(
+            chunks.active_voxel_deadline(&Vec3(vx, vy, vz)),
+            Some(7),
+            "opt-in crop in loaded interested chunk must be scheduled at current tick"
+        );
+    }
+
+    #[test]
+    fn random_tick_skips_chunks_without_interest() {
+        let config = WorldConfig::new()
+            .chunk_size(16)
+            .max_height(16)
+            .sub_chunks(1)
+            .random_tick_speed(64)
+            .max_random_ticks_per_tick(64)
+            .seed(1)
+            .build();
+
+        let mut registry = Registry::new();
+        registry.register_block(&growth_block(42));
+
+        let mut chunks = Chunks::new(&config);
+        let mut chunk = ready_chunk(0, 0, 16, 16, 1);
+        let raw = BlockUtils::insert_id(0, 42);
+        assert!(chunk.set_raw_voxel(1, 1, 1, raw));
+        chunks.add(chunk);
+
+        let interests = ChunkInterests::new(); // no interest
+        let taken = sample_random_ticks(&mut chunks, &registry, &interests, &config, 1);
+        assert_eq!(taken, 0);
+        assert!(chunks.active_voxel_deadline(&Vec3(1, 1, 1)).is_none());
+    }
+
+    #[test]
+    fn random_tick_budget_caps_samples() {
+        let config = WorldConfig::new()
+            .chunk_size(16)
+            .max_height(16)
+            .sub_chunks(1)
+            .random_tick_speed(100)
+            .max_random_ticks_per_tick(7)
+            .seed(1)
+            .build();
+
+        let registry = Registry::new();
+        let mut chunks = Chunks::new(&config);
+        chunks.add(ready_chunk(0, 0, 16, 16, 1));
+        let mut interests = ChunkInterests::new();
+        interests.add("tester", &Vec2(0, 0));
+
+        let taken = sample_random_ticks(&mut chunks, &registry, &interests, &config, 1);
+        assert_eq!(taken, 7);
+    }
+
+    #[test]
+    fn non_random_tickable_active_block_not_marked() {
+        let config = WorldConfig::new()
+            .chunk_size(16)
+            .max_height(16)
+            .sub_chunks(1)
+            .random_tick_speed(16 * 16 * 16)
+            .max_random_ticks_per_tick(16 * 16 * 16)
+            .seed(1)
+            .build();
+
+        let mut registry = Registry::new();
+        // Active but NOT random_tickable (copper-like).
+        let wire = Block::new("Wire")
+            .id(99)
+            .active_fn(|_, _, _| 1, |_, _, _| vec![])
+            .build();
+        assert!(wire.is_active);
+        assert!(!wire.is_random_tickable);
+        registry.register_block(&wire);
+
+        let mut chunks = Chunks::new(&config);
+        let mut chunk = ready_chunk(0, 0, 16, 16, 1);
+        assert!(chunk.set_raw_voxel(2, 2, 2, BlockUtils::insert_id(0, 99)));
+        chunks.add(chunk);
+        let mut interests = ChunkInterests::new();
+        interests.add("tester", &Vec2(0, 0));
+
+        sample_random_ticks(&mut chunks, &registry, &interests, &config, 3);
+        assert!(chunks.active_voxel_deadline(&Vec3(2, 2, 2)).is_none());
+    }
+}

--- a/server/world/systems/chunk/updating.rs
+++ b/server/world/systems/chunk/updating.rs
@@ -5,10 +5,10 @@ use nanoid::nanoid;
 use specs::{Entities, LazyUpdate, ReadExpect, System, WorldExt, WriteExpect, WriteStorage};
 
 use crate::{
-    beer_lambert_transmit, BlockUtils, ChunkInterests, ChunkUtils, Chunks, ClientFilter,
-    CurrentChunkComp, ETypeComp, EntityFlag, IDComp, JsonComp, LightColor, LightNode, Lights,
-    Mesher, Message, MessageQueues, MessageType, MetadataComp, Registry, Stats, UpdateProtocol,
-    Vec2, Vec3, VoxelAccess, VoxelComp, WorldConfig,
+    beer_lambert_transmit, sample_random_ticks, BlockUtils, ChunkInterests, ChunkUtils, Chunks,
+    ClientFilter, CurrentChunkComp, ETypeComp, EntityFlag, IDComp, JsonComp, LightColor, LightNode,
+    Lights, Mesher, Message, MessageQueues, MessageType, MetadataComp, Registry, Stats,
+    UpdateProtocol, Vec2, Vec3, VoxelAccess, VoxelComp, WorldConfig,
 };
 
 pub const VOXEL_NEIGHBORS: [[i32; 3]; 6] = [
@@ -858,15 +858,24 @@ impl<'a> System<'a> for ChunkUpdatingSystem {
 
         chunks.clear_cache();
 
-        // Collect all due active voxels
+        // Collect all due active voxels.
+        // Lazy discard: after an earliest-deadline upsert the heap may hold a
+        // stale later entry for the same voxel. Only fire when the heap tick
+        // still matches the deadline stored in active_voxel_set.
         let mut due_voxels = Vec::new();
         while let Some(Reverse(active)) = chunks.active_voxel_heap.peek() {
             if active.tick > current_tick {
                 break;
             }
             let Reverse(active) = chunks.active_voxel_heap.pop().unwrap();
-            if chunks.active_voxel_set.remove(&active.voxel).is_some() {
-                due_voxels.push(active.voxel);
+            match chunks.active_voxel_set.get(&active.voxel).copied() {
+                Some(scheduled) if scheduled == active.tick => {
+                    chunks.active_voxel_set.remove(&active.voxel);
+                    due_voxels.push(active.voxel);
+                }
+                _ => {
+                    // Stale entry (rescheduled earlier, or already processed).
+                }
             }
         }
 
@@ -917,6 +926,57 @@ impl<'a> System<'a> for ChunkUpdatingSystem {
             max_updates_per_tick,
         );
         all_results.extend(results);
+
+        // Minecraft-style subchunk random ticks (plants). Runs AFTER the
+        // scheduled active queue so copper/neighbor wakes are never starved.
+        // Newly marked voxels are popped immediately below so growth can
+        // advance on the same world tick when budget allows.
+        let _random_samples = sample_random_ticks(
+            &mut chunks,
+            &registry,
+            &interests,
+            &config,
+            current_tick,
+        );
+
+        let mut random_due = Vec::new();
+        while let Some(Reverse(active)) = chunks.active_voxel_heap.peek() {
+            if active.tick > current_tick {
+                break;
+            }
+            let Reverse(active) = chunks.active_voxel_heap.pop().unwrap();
+            match chunks.active_voxel_set.get(&active.voxel).copied() {
+                Some(scheduled) if scheduled == active.tick => {
+                    chunks.active_voxel_set.remove(&active.voxel);
+                    random_due.push(active.voxel);
+                }
+                _ => {}
+            }
+        }
+        random_due.sort_by(|a, b| (a.0, a.1, a.2).cmp(&(b.0, b.1, b.2)));
+        for voxel in random_due.iter() {
+            let Vec3(vx, vy, vz) = *voxel;
+            let id = chunks.get_voxel(vx, vy, vz);
+            let block = registry.get_block_by_id(id);
+            if let Some(updater) = &block.active_updater {
+                let updates = updater(Vec3(vx, vy, vz), &*chunks, &registry);
+                for (pos, val) in updates {
+                    chunks.update_voxel(&pos, val);
+                }
+            }
+            let results = process_pending_updates(
+                &mut chunks,
+                &mut mesher,
+                &lazy,
+                &entities,
+                &mut json_storage,
+                &config,
+                &registry,
+                current_tick,
+                max_updates_per_tick,
+            );
+            all_results.extend(results);
+        }
 
         if !all_results.is_empty() {
             // Route each update only to clients whose chunk interest covers a

--- a/server/world/voxels/block.rs
+++ b/server/world/voxels/block.rs
@@ -1477,6 +1477,13 @@ pub struct Block {
         Option<Arc<dyn Fn(Vec3<i32>, &dyn VoxelAccess, &Registry) -> u64 + Send + Sync>>,
 
     pub is_active: bool,
+
+    /// When true, the Minecraft-style subchunk random-tick sampler may invoke
+    /// this block's `active_updater` (scheduled via `mark_voxel_active` at the
+    /// current tick). Default false -- copper/fluids stay neighbor/scheduled
+    /// only; plant growth opts in explicitly.
+    #[serde(default)]
+    pub is_random_tickable: bool,
 }
 
 impl Block {
@@ -1751,6 +1758,7 @@ pub struct BlockBuilder {
     is_see_through: bool,
     occludes_fluid: bool,
     is_plant: bool,
+    is_random_tickable: bool,
     requires_support: SupportRequirement,
     is_px_transparent: bool,
     is_py_transparent: bool,
@@ -1852,6 +1860,14 @@ impl BlockBuilder {
 
     pub fn is_plant(mut self, is_plant: bool) -> Self {
         self.is_plant = is_plant;
+        self
+    }
+
+    /// Opt this block into the subchunk random-tick sampler (Minecraft-style
+    /// plant growth). Requires `active_fn` so `is_active` is true; the sampler
+    /// marks matching voxels active at the current tick for the updater to run.
+    pub fn is_random_tickable(mut self, is_random_tickable: bool) -> Self {
+        self.is_random_tickable = is_random_tickable;
         self
     }
 
@@ -2124,6 +2140,7 @@ impl BlockBuilder {
             is_active: self.active_updater.is_some() && self.active_ticker.is_some(),
             active_ticker: self.active_ticker,
             active_updater: self.active_updater,
+            is_random_tickable: self.is_random_tickable,
             is_entity: self.is_entity,
             default_entity_json: self.default_entity_json,
         }

--- a/server/world/voxels/chunks.rs
+++ b/server/world/voxels/chunks.rs
@@ -531,8 +531,26 @@ impl Chunks {
         }
     }
 
+    /// Schedule `voxel` to become active at absolute tick `active_at`.
+    ///
+    /// Earliest-deadline upsert:
+    /// - if the voxel is not queued, insert it
+    /// - if already queued and `active_at` is **earlier** than the stored
+    ///   deadline, reschedule to the earlier tick (stale later heap entries
+    ///   are lazily discarded when popped -- see ChunkUpdatingSystem)
+    /// - if already queued and `active_at` is later-or-equal, this is a no-op
     pub fn mark_voxel_active(&mut self, voxel: &Vec3<i32>, active_at: u64) {
-        if self.active_voxel_set.contains_key(voxel) {
+        if let Some(&existing) = self.active_voxel_set.get(voxel) {
+            if active_at >= existing {
+                return;
+            }
+            // Earlier deadline wins. Leave the stale later heap entry; the
+            // pop path only fires when the heap tick matches the set.
+            self.active_voxel_set.insert(voxel.clone(), active_at);
+            self.active_voxel_heap.push(Reverse(ActiveVoxel {
+                tick: active_at,
+                voxel: voxel.clone(),
+            }));
             return;
         }
         self.active_voxel_set.insert(voxel.clone(), active_at);
@@ -540,6 +558,11 @@ impl Chunks {
             tick: active_at,
             voxel: voxel.clone(),
         }));
+    }
+
+    /// Absolute tick currently scheduled for `voxel`, if any.
+    pub fn active_voxel_deadline(&self, voxel: &Vec3<i32>) -> Option<u64> {
+        self.active_voxel_set.get(voxel).copied()
     }
 
     /// Add a chunk to be saved.
@@ -683,5 +706,78 @@ impl VoxelAccess for Chunks {
 
     fn contains(&self, vx: i32, vy: i32, vz: i32) -> bool {
         self.raw_chunk_by_voxel(vx, vy, vz).is_some()
+    }
+}
+
+
+#[cfg(test)]
+mod active_voxel_upsert_tests {
+    use super::*;
+    use crate::WorldConfig;
+
+    fn empty_chunks() -> Chunks {
+        Chunks::new(&WorldConfig::new().build())
+    }
+
+    #[test]
+    fn mark_voxel_active_earlier_deadline_wins() {
+        let mut chunks = empty_chunks();
+        let voxel = Vec3(1, 2, 3);
+        chunks.mark_voxel_active(&voxel, 100);
+        assert_eq!(chunks.active_voxel_deadline(&voxel), Some(100));
+
+        chunks.mark_voxel_active(&voxel, 10);
+        assert_eq!(chunks.active_voxel_deadline(&voxel), Some(10));
+
+        // Later-or-equal is a no-op.
+        chunks.mark_voxel_active(&voxel, 10);
+        assert_eq!(chunks.active_voxel_deadline(&voxel), Some(10));
+        chunks.mark_voxel_active(&voxel, 50);
+        assert_eq!(chunks.active_voxel_deadline(&voxel), Some(10));
+    }
+
+    #[test]
+    fn mark_voxel_active_lazy_discards_stale_later_heap_entry() {
+        let mut chunks = empty_chunks();
+        let voxel = Vec3(4, 5, 6);
+        chunks.mark_voxel_active(&voxel, 100);
+        chunks.mark_voxel_active(&voxel, 10);
+
+        // Simulate the ChunkUpdatingSystem pop loop at tick 10.
+        let current_tick = 10u64;
+        let mut due = Vec::new();
+        while let Some(Reverse(active)) = chunks.active_voxel_heap.peek() {
+            if active.tick > current_tick {
+                break;
+            }
+            let Reverse(active) = chunks.active_voxel_heap.pop().unwrap();
+            match chunks.active_voxel_set.get(&active.voxel).copied() {
+                Some(scheduled) if scheduled == active.tick => {
+                    chunks.active_voxel_set.remove(&active.voxel);
+                    due.push(active.voxel);
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(due, vec![voxel.clone()]);
+        assert!(chunks.active_voxel_deadline(&voxel).is_none());
+
+        // Stale T+100 entry must not fire later.
+        let current_tick = 100u64;
+        let mut due2 = Vec::new();
+        while let Some(Reverse(active)) = chunks.active_voxel_heap.peek() {
+            if active.tick > current_tick {
+                break;
+            }
+            let Reverse(active) = chunks.active_voxel_heap.pop().unwrap();
+            match chunks.active_voxel_set.get(&active.voxel).copied() {
+                Some(scheduled) if scheduled == active.tick => {
+                    chunks.active_voxel_set.remove(&active.voxel);
+                    due2.push(active.voxel);
+                }
+                _ => {}
+            }
+        }
+        assert!(due2.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Per interested Ready chunk, each 16³-style section samples `random_tick_speed` positions/tick (default 3 = MC gamerule). Opt-in via `BlockBuilder::is_random_tickable`; sampler `mark_voxel_active` at current tick.
- Cap `max_random_ticks_per_tick` (default 2048). Scheduled active queue always runs first so copper is never starved.
- Earliest-deadline active upsert path for snappier copper wakes (Town CODE SHIP tip `fe6b92648`).

## Test plan
- [x] Tip already on Hetzner town-staging submodule at `fe6b92648`
- [ ] Smoke: copper upsert path present after pin
- [ ] Smoke: one `is_random_tickable` crop advances without PorchCropGrowthSystem poll

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the per-tick chunk update path and active-voxel scheduling used by fluids/copper; mitigated by running scheduled work first, caps, and tests, but regressions in neighbor-active behavior are possible.
> 
> **Overview**
> Adds **Minecraft-style random ticks** for plant-style growth without scanning every crop each tick. `WorldConfig` gains `random_tick_speed` (default 3 samples per subchunk section per tick) and `max_random_ticks_per_tick` (default 2048). Blocks opt in via **`is_random_tickable`** on `BlockBuilder`; copper-like active blocks stay off the sampler by default.
> 
> Each tick, **`sample_random_ticks`** walks **interested, Ready** chunks, picks deterministic random positions per section, and **`mark_voxel_active`** at the current tick when the block is random-tickable and active. **`ChunkUpdatingSystem`** still drains the **scheduled** active queue first, then runs the sampler and processes any voxels queued at the current tick so growth can run the same tick when budget allows.
> 
> **`mark_voxel_active`** now uses **earliest-deadline upsert** (earlier ticks replace later ones; later/equal are no-ops). Heap pops **lazy-discard** stale entries when the stored deadline no longer matches, with unit tests on upsert and sampler behavior (interest, budget, opt-in).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6b926481066a3cd5bcc7458788cbff8210ed93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->