### PR TITLE
feat: opt-in level-of-detail (LOD) meshing for distant chunks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ prost-build = "0.12.4"
 awc = "3"
 criterion = { version = "0.5", features = ["html_reports"] }
 kdtree = "0.7"
+lz4_flex = "0.11"
 tokio = { version = "1", features = ["sync", "macros", "rt", "time", "test-util"] }
 
 [[bench]]

--- a/crates/mesher/src/lib.rs
+++ b/crates/mesher/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod lod;
 pub mod mesher;
 
+pub use lod::{downsample_chunk, mesh_chunk_lod, mesh_coarse_chunk};
 pub use mesher::{
     mesh_chunk, mesh_chunk_with_registry, mesh_chunk_with_registry_chunks, mesh_space_greedy, Block,
     ChunkData, GeometryProtocol, MeshConfig, MeshInput, MeshInputNoRegistry, MeshOutput, Registry,

--- a/crates/mesher/src/lod.rs
+++ b/crates/mesher/src/lod.rs
@@ -1,0 +1,1103 @@
+//! Level-of-detail (LOD) chunk meshing.
+//!
+//! A chunk at LOD level `L` is rendered from a grid downsampled by
+//! `factor = 2^L`: every `factor^3` block cell collapses into one cell that is
+//! meshed as a `factor`-sized cube. The coarse grid is fed through the exact
+//! same greedy mesher as full-resolution chunks ([`mesh_space_greedy`]), so
+//! materials, texture atlas ranges, ambient occlusion, fluids, and
+//! transparency all behave identically — the only post-processing is scaling
+//! the output positions by `factor`.
+//!
+//! # Seam strategy: closed hulls + conservative downsampling
+//!
+//! LOD meshes are built *per chunk in isolation*: everything outside the
+//! chunk is treated as void, so every solid coarse cell on the chunk border
+//! emits its border face. Each LOD chunk is therefore a closed (watertight)
+//! hull on its side boundaries, and the union of closed hulls cannot have
+//! cracks no matter which LOD levels end up adjacent — correctness never
+//! depends on what level a neighbor is displayed at, and no chunk needs
+//! remeshing when a neighbor changes level.
+//!
+//! The boundary between the full-detail region and the first LOD ring is
+//! covered by a conservative downsampling rule: a coarse cell's
+//! representative is *opaque* whenever the cell contains at least one opaque
+//! block. A full-detail chunk only suppresses a border face when the true
+//! neighbor voxel is opaque, and that voxel forces the neighboring coarse
+//! cell — and thus the coarse chunk's closed border wall in the very same
+//! plane — to be opaque. Every suppressed full-detail face is covered.
+//!
+//! Coplanar walls from both sides of a border face in opposite directions,
+//! so backface culling shows at most one of them from any viewpoint (no
+//! z-fighting). Non-opaque faces keep the mesher's existing sub-voxel inset
+//! and are never exactly coplanar.
+//!
+//! The cost of the closed hull is hidden interior wall geometry at chunk
+//! borders. Greedy meshing collapses those walls to a handful of quads, and
+//! LOD chunks are distant by definition, so the overdraw is negligible next
+//! to the correctness guarantee.
+
+use voxelize_core::LightUtils;
+
+use crate::mesher::{
+    mesh_space_greedy, ChunkData, GeometryProtocol, Registry, VoxelSpace, FLUID_BASE_HEIGHT,
+    FLUID_STAGE_DROPOFF,
+};
+
+/// Downsampled stand-in for one coarse cell, chosen from the fine voxels the
+/// cell contains.
+///
+/// Picks are `(preference rank, fine y, id)` tuples compared
+/// lexicographically: representatives are surface-biased (topmost wins, so
+/// grass hills stay grass at distance), with ids that carry no per-position
+/// state ranked above ones that do, and the id as a deterministic tiebreak.
+#[derive(Default, Clone, Copy)]
+struct CellAccumulator {
+    /// Best opaque pick — mandatory representative when present (seam
+    /// safety, see module docs).
+    opaque: Option<(u8, u32, u32)>,
+    /// Best non-opaque solid pick (leaves, glass) — used only when the cell
+    /// holds no opaque block.
+    solid: Option<(u8, u32, u32)>,
+    /// Topmost fluid pick `(fine y, local y within the cell, raw voxel)` —
+    /// used only when the cell holds no solid block at all.
+    fluid: Option<(u32, u32, u32)>,
+    /// Per-channel maxima over the cell (sun, red, green, blue). Max — not
+    /// average — so lit surfaces stay as bright as the adjacent full-detail
+    /// ring and no dark seams appear at LOD boundaries.
+    light_max: [u32; 4],
+}
+
+#[inline]
+fn upgrade_pick(slot: &mut Option<(u8, u32, u32)>, candidate: (u8, u32, u32)) {
+    if slot.map_or(true, |current| candidate > current) {
+        *slot = Some(candidate);
+    }
+}
+
+const CLASS_OPAQUE: u8 = 1 << 0;
+const CLASS_SOLID: u8 = 1 << 1;
+const CLASS_FLUID: u8 = 1 << 2;
+const CLASS_PREFERRED: u8 = 1 << 3;
+
+/// Per-block-id classification lookup table for the downsampling hot loop.
+///
+/// - `OPAQUE`: occludes neighbors at full detail, therefore *must* solidify
+///   its coarse cell — this is the invariant that keeps the full-detail /
+///   LOD boundary watertight (see module docs).
+/// - `SOLID`: substantial enough to contribute mass even though it does not
+///   occlude (full-cube see-through blocks such as leaves and glass). Plants,
+///   fences, torches and other partial shapes are ignored: at distance they
+///   are subpixel, and turning them into full cells would bloat terrain.
+/// - `FLUID`: contributes a water surface when the cell has no solid mass.
+/// - `PREFERRED`: an id safe to use as a representative without dragging in
+///   per-position state (no isolated faces, no dynamic patterns).
+struct LodClassifier {
+    classes: Vec<u8>,
+}
+
+impl LodClassifier {
+    fn new(registry: &Registry) -> Self {
+        let max_id = registry
+            .blocks_by_id
+            .iter()
+            .map(|(id, _)| *id as usize)
+            .max()
+            .unwrap_or(0);
+        let mut classes = vec![0u8; max_id + 1];
+
+        for (id, block) in &registry.blocks_by_id {
+            let mut class = 0u8;
+
+            if block.is_fluid {
+                class |= CLASS_FLUID;
+            } else if !block.is_empty && !block.is_plant {
+                if block.is_opaque {
+                    class |= CLASS_OPAQUE | CLASS_SOLID;
+                } else if block.is_full_cube() {
+                    class |= CLASS_SOLID;
+                }
+            }
+
+            let has_isolated_faces = block.faces.iter().any(|face| face.isolated);
+            if class & CLASS_SOLID != 0 && !has_isolated_faces && block.dynamic_patterns.is_none()
+            {
+                class |= CLASS_PREFERRED;
+            }
+
+            classes[*id as usize] = class;
+        }
+
+        Self { classes }
+    }
+
+    #[inline]
+    fn class_of(&self, id: u32) -> u8 {
+        self.classes.get(id as usize).copied().unwrap_or(0)
+    }
+}
+
+/// Encode a fluid surface height (fraction of a coarse cell, in `(0, 1]`)
+/// into the voxel stage bits so the unmodified mesher reproduces it.
+///
+/// The mesher computes a fluid cell's surface as
+/// `FLUID_BASE_HEIGHT - stage * FLUID_STAGE_DROPOFF` in cell units. Scaling a
+/// coarse cell by `factor` would multiply that height by `factor` and float
+/// distant water a block or more above the true surface, so the downsampler
+/// solves for the stage whose decoded height, times `factor`, lands closest
+/// to the true fine-grid water level. Heights above `FLUID_BASE_HEIGHT`
+/// clamp to stage 0 — a hair low, which reads fine and never poke through
+/// the adjacent full-detail water.
+fn encode_fluid_stage_for_height(target_height: f32) -> u32 {
+    if target_height >= FLUID_BASE_HEIGHT {
+        return 0;
+    }
+    let stage = ((FLUID_BASE_HEIGHT - target_height) / FLUID_STAGE_DROPOFF).round() as i32;
+    stage.clamp(0, 15) as u32
+}
+
+/// Downsample a full-resolution chunk into a coarse [`ChunkData`] whose every
+/// cell covers `factor^3` fine voxels.
+///
+/// `voxels` and `lights` are the chunk's raw arrays with `shape`
+/// `[size, height, size]` in the engine's `x -> y -> z` (row-major) layout.
+/// `shape` dimensions must be divisible by `factor`.
+///
+/// Representative selection per cell, in priority order:
+/// 1. topmost opaque block (preferring ids without isolated faces or dynamic
+///    patterns) — mandatory for seam safety, see [`LodClassifier`],
+/// 2. topmost non-opaque solid (leaves, glass),
+/// 3. topmost fluid, with its stage re-encoded so the scaled surface height
+///    matches the true water level,
+/// 4. air.
+///
+/// Rotation and stage bits of solid representatives are stripped: coarse
+/// cells are plain axis-aligned cubes.
+pub fn downsample_chunk(
+    voxels: &[u32],
+    lights: &[u32],
+    shape: [usize; 3],
+    factor: usize,
+    registry: &Registry,
+) -> ChunkData {
+    assert!(factor >= 2, "LOD factor must be at least 2");
+    assert!(
+        shape[0] % factor == 0 && shape[1] % factor == 0 && shape[2] % factor == 0,
+        "chunk shape {shape:?} must be divisible by LOD factor {factor}"
+    );
+
+    let [size_x, size_y, size_z] = shape;
+    let coarse_shape = [size_x / factor, size_y / factor, size_z / factor];
+    let [cs_x, cs_y, cs_z] = coarse_shape;
+
+    let classifier = LodClassifier::new(registry);
+    let mut cells = vec![CellAccumulator::default(); cs_x * cs_y * cs_z];
+
+    let coarse_index =
+        |cx: usize, cy: usize, cz: usize| -> usize { cx * cs_y * cs_z + cy * cs_z + cz };
+
+    for fx in 0..size_x {
+        let cx = fx / factor;
+        for fy in 0..size_y {
+            let cy = fy / factor;
+            let local_y = (fy % factor) as u32;
+            let row = fx * size_y * size_z + fy * size_z;
+            for fz in 0..size_z {
+                let cz = fz / factor;
+                let fine_index = row + fz;
+
+                let cell = &mut cells[coarse_index(cx, cy, cz)];
+
+                let light = lights[fine_index];
+                if light != 0 {
+                    let (sun, red, green, blue) = LightUtils::extract_all(light);
+                    cell.light_max[0] = cell.light_max[0].max(sun);
+                    cell.light_max[1] = cell.light_max[1].max(red);
+                    cell.light_max[2] = cell.light_max[2].max(green);
+                    cell.light_max[3] = cell.light_max[3].max(blue);
+                }
+
+                let raw = voxels[fine_index];
+                let id = raw & 0xFFFF;
+                if id == 0 {
+                    continue;
+                }
+                let class = classifier.class_of(id);
+                if class == 0 {
+                    continue;
+                }
+
+                let preferred = (class & CLASS_PREFERRED != 0) as u8;
+                if class & CLASS_OPAQUE != 0 {
+                    upgrade_pick(&mut cell.opaque, (preferred, fy as u32, id));
+                } else if class & CLASS_SOLID != 0 {
+                    upgrade_pick(&mut cell.solid, (preferred, fy as u32, id));
+                } else if class & CLASS_FLUID != 0 {
+                    if cell.fluid.map_or(true, |(top_y, ..)| fy as u32 >= top_y) {
+                        cell.fluid = Some((fy as u32, local_y, raw));
+                    }
+                }
+            }
+        }
+    }
+
+    let mut coarse_voxels = vec![0u32; cells.len()];
+    let mut coarse_lights = vec![0u32; cells.len()];
+
+    for (index, cell) in cells.iter().enumerate() {
+        coarse_voxels[index] = if let Some((.., id)) = cell.opaque {
+            id
+        } else if let Some((.., id)) = cell.solid {
+            id
+        } else if let Some((_, local_y, raw)) = cell.fluid {
+            let id = raw & 0xFFFF;
+            let fine_stage = (raw >> 24) & 0xF;
+            let fine_height =
+                (FLUID_BASE_HEIGHT - fine_stage as f32 * FLUID_STAGE_DROPOFF).max(0.1);
+            let target_height = (local_y as f32 + fine_height) / factor as f32;
+            id | (encode_fluid_stage_for_height(target_height) << 24)
+        } else {
+            0
+        };
+
+        let mut light = 0u32;
+        light = LightUtils::insert_sunlight(light, cell.light_max[0]);
+        light = LightUtils::insert_red_light(light, cell.light_max[1]);
+        light = LightUtils::insert_green_light(light, cell.light_max[2]);
+        light = LightUtils::insert_blue_light(light, cell.light_max[3]);
+        coarse_lights[index] = light;
+    }
+
+    ChunkData {
+        voxels: coarse_voxels,
+        lights: coarse_lights,
+        shape: coarse_shape,
+        min: [0, 0, 0],
+    }
+}
+
+/// Mesh one chunk at LOD `level` (downsample factor `2^level`).
+///
+/// The coarse grid is meshed in isolation — everything outside the chunk is
+/// void — which produces the closed hull described in the module docs. The
+/// mesher runs in coarse cell units and the resulting positions are scaled
+/// by the factor, so the returned geometry is in block units relative to the
+/// chunk's min corner, exactly like a full-resolution chunk mesh.
+pub fn mesh_chunk_lod(
+    voxels: &[u32],
+    lights: &[u32],
+    shape: [usize; 3],
+    level: u32,
+    registry: &Registry,
+) -> Vec<GeometryProtocol> {
+    assert!(level >= 1, "LOD level must be at least 1");
+    let factor = 1usize << level;
+
+    let coarse = downsample_chunk(voxels, lights, shape, factor, registry);
+    mesh_coarse_chunk(&coarse, factor, registry)
+}
+
+/// Mesh an already-downsampled chunk as a closed hull and scale the output
+/// back to block units.
+pub fn mesh_coarse_chunk(
+    coarse: &ChunkData,
+    factor: usize,
+    registry: &Registry,
+) -> Vec<GeometryProtocol> {
+    let [cs_x, cs_y, cs_z] = coarse.shape;
+
+    // A single-chunk neighborhood: only the center slot is populated, so the
+    // space reports `contains() == false` for every out-of-chunk coordinate
+    // and the mesher emits the closed border walls.
+    let mut chunks: Vec<Option<ChunkData>> = (0..9).map(|_| None).collect();
+    chunks[4] = Some(ChunkData {
+        voxels: coarse.voxels.clone(),
+        lights: coarse.lights.clone(),
+        shape: coarse.shape,
+        min: [0, 0, 0],
+    });
+
+    let space = VoxelSpace::new(&chunks, cs_x as i32, [0, 0]);
+
+    let min = [0, 0, 0];
+    let max = [cs_x as i32, cs_y as i32, cs_z as i32];
+
+    let mut geometries = mesh_space_greedy(&min, &max, &space, registry);
+
+    let scale = factor as f32;
+    for geometry in &mut geometries {
+        for position in &mut geometry.positions {
+            *position *= scale;
+        }
+        if let Some(at) = &mut geometry.at {
+            at[0] *= factor as i32;
+            at[1] *= factor as i32;
+            at[2] *= factor as i32;
+        }
+    }
+
+    geometries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mesher::{Block, MeshConfig};
+    use voxelize_core::{BlockFace, CornerData, AABB, UV};
+
+    const AIR: u32 = 0;
+    const STONE: u32 = 1;
+    const GRASS: u32 = 2;
+    const WATER: u32 = 3;
+    const LEAVES: u32 = 4;
+    const PLANT: u32 = 5;
+    const SIGN: u32 = 6;
+
+    fn six_faces() -> Vec<BlockFace> {
+        let corner = |x: f32, y: f32, z: f32, u: f32, v: f32| CornerData {
+            pos: [x, y, z],
+            uv: [u, v],
+        };
+        let face = |name: &str, dir: [i32; 3], corners: [CornerData; 4]| BlockFace {
+            name: name.to_string(),
+            name_lower: name.to_string(),
+            dir,
+            independent: false,
+            isolated: false,
+            texture_group: None,
+            range: UV::default(),
+            corners,
+        };
+
+        vec![
+            face(
+                "px",
+                [1, 0, 0],
+                [
+                    corner(1.0, 1.0, 1.0, 0.0, 1.0),
+                    corner(1.0, 0.0, 1.0, 0.0, 0.0),
+                    corner(1.0, 1.0, 0.0, 1.0, 1.0),
+                    corner(1.0, 0.0, 0.0, 1.0, 0.0),
+                ],
+            ),
+            face(
+                "py",
+                [0, 1, 0],
+                [
+                    corner(0.0, 1.0, 1.0, 1.0, 1.0),
+                    corner(1.0, 1.0, 1.0, 0.0, 1.0),
+                    corner(0.0, 1.0, 0.0, 1.0, 0.0),
+                    corner(1.0, 1.0, 0.0, 0.0, 0.0),
+                ],
+            ),
+            face(
+                "pz",
+                [0, 0, 1],
+                [
+                    corner(0.0, 0.0, 1.0, 0.0, 0.0),
+                    corner(1.0, 0.0, 1.0, 1.0, 0.0),
+                    corner(0.0, 1.0, 1.0, 0.0, 1.0),
+                    corner(1.0, 1.0, 1.0, 1.0, 1.0),
+                ],
+            ),
+            face(
+                "nx",
+                [-1, 0, 0],
+                [
+                    corner(0.0, 1.0, 0.0, 0.0, 1.0),
+                    corner(0.0, 0.0, 0.0, 0.0, 0.0),
+                    corner(0.0, 1.0, 1.0, 1.0, 1.0),
+                    corner(0.0, 0.0, 1.0, 1.0, 0.0),
+                ],
+            ),
+            face(
+                "ny",
+                [0, -1, 0],
+                [
+                    corner(1.0, 0.0, 1.0, 1.0, 0.0),
+                    corner(0.0, 0.0, 1.0, 0.0, 0.0),
+                    corner(1.0, 0.0, 0.0, 1.0, 1.0),
+                    corner(0.0, 0.0, 0.0, 0.0, 1.0),
+                ],
+            ),
+            face(
+                "nz",
+                [0, 0, -1],
+                [
+                    corner(1.0, 0.0, 0.0, 0.0, 0.0),
+                    corner(0.0, 0.0, 0.0, 1.0, 0.0),
+                    corner(1.0, 1.0, 0.0, 0.0, 1.0),
+                    corner(0.0, 1.0, 0.0, 1.0, 1.0),
+                ],
+            ),
+        ]
+    }
+
+    fn full_cube_aabb() -> Vec<AABB> {
+        vec![AABB {
+            min_x: 0.0,
+            min_y: 0.0,
+            min_z: 0.0,
+            max_x: 1.0,
+            max_y: 1.0,
+            max_z: 1.0,
+        }]
+    }
+
+    fn base_block(id: u32, name: &str) -> Block {
+        Block {
+            id,
+            name: name.to_string(),
+            name_lower: name.to_lowercase(),
+            rotatable: false,
+            y_rotatable: false,
+            is_empty: false,
+            is_fluid: false,
+            is_waterlogged: false,
+            is_opaque: true,
+            is_see_through: false,
+            is_transparent: [false; 6],
+            transparent_standalone: false,
+            occludes_fluid: false,
+            is_plant: false,
+            faces: six_faces(),
+            aabbs: full_cube_aabb(),
+            dynamic_patterns: None,
+        }
+    }
+
+    fn test_registry() -> Registry {
+        let mut air = base_block(AIR, "Air");
+        air.is_empty = true;
+        air.is_opaque = false;
+        air.is_transparent = [true; 6];
+        air.faces = vec![];
+        air.aabbs = vec![];
+
+        let stone = base_block(STONE, "Stone");
+        let grass = base_block(GRASS, "Grass Block");
+
+        let mut water = base_block(WATER, "Water");
+        water.is_fluid = true;
+        water.is_opaque = false;
+        water.is_see_through = true;
+        water.is_transparent = [true; 6];
+
+        let mut leaves = base_block(LEAVES, "Leaves");
+        leaves.is_opaque = false;
+        leaves.is_see_through = true;
+        leaves.is_transparent = [true; 6];
+        leaves.transparent_standalone = true;
+
+        let mut plant = base_block(PLANT, "Plant");
+        plant.is_opaque = false;
+        plant.is_see_through = true;
+        plant.is_transparent = [true; 6];
+        plant.is_plant = true;
+        plant.aabbs = vec![];
+
+        let mut sign = base_block(SIGN, "Sign");
+        for face in &mut sign.faces {
+            if face.name == "pz" {
+                face.isolated = true;
+            }
+        }
+
+        let mut registry = Registry::new(vec![
+            (AIR, air),
+            (STONE, stone),
+            (GRASS, grass),
+            (WATER, water),
+            (LEAVES, leaves),
+            (PLANT, plant),
+            (SIGN, sign),
+        ]);
+        registry.build_cache();
+        registry
+    }
+
+    struct FineChunk {
+        voxels: Vec<u32>,
+        lights: Vec<u32>,
+        shape: [usize; 3],
+    }
+
+    impl FineChunk {
+        fn new(shape: [usize; 3]) -> Self {
+            let volume = shape[0] * shape[1] * shape[2];
+            Self {
+                voxels: vec![0; volume],
+                lights: vec![0; volume],
+                shape,
+            }
+        }
+
+        fn index(&self, x: usize, y: usize, z: usize) -> usize {
+            x * self.shape[1] * self.shape[2] + y * self.shape[2] + z
+        }
+
+        fn set(&mut self, x: usize, y: usize, z: usize, raw: u32) {
+            let index = self.index(x, y, z);
+            self.voxels[index] = raw;
+        }
+
+        fn set_light(&mut self, x: usize, y: usize, z: usize, light: u32) {
+            let index = self.index(x, y, z);
+            self.lights[index] = light;
+        }
+
+        fn coarse(&self, factor: usize, registry: &Registry) -> ChunkData {
+            downsample_chunk(&self.voxels, &self.lights, self.shape, factor, registry)
+        }
+    }
+
+    fn coarse_at(coarse: &ChunkData, x: usize, y: usize, z: usize) -> u32 {
+        coarse.voxels[x * coarse.shape[1] * coarse.shape[2] + y * coarse.shape[2] + z]
+    }
+
+    /// Deterministic pseudo-random heightmap for structural tests.
+    fn test_height(x: i32, z: i32) -> usize {
+        let h = (x as u32).wrapping_mul(2654435761) ^ (z as u32).wrapping_mul(40503);
+        4 + (h % 9) as usize
+    }
+
+    #[test]
+    fn cell_with_any_opaque_voxel_becomes_opaque() {
+        let mut fine = FineChunk::new([4, 4, 4]);
+        fine.set(3, 1, 2, STONE);
+
+        let coarse = fine.coarse(2, &test_registry());
+
+        assert_eq!(coarse.shape, [2, 2, 2]);
+        assert_eq!(
+            coarse_at(&coarse, 1, 0, 1),
+            STONE,
+            "one opaque voxel out of eight must solidify the coarse cell (seam invariant)"
+        );
+        assert_eq!(coarse_at(&coarse, 0, 0, 0), AIR);
+    }
+
+    #[test]
+    fn representative_is_topmost_opaque_block() {
+        let mut fine = FineChunk::new([4, 4, 4]);
+        fine.set(0, 0, 0, STONE);
+        fine.set(0, 1, 0, STONE);
+        fine.set(0, 2, 0, STONE);
+        fine.set(0, 3, 0, GRASS);
+
+        let coarse = fine.coarse(4, &test_registry());
+
+        assert_eq!(coarse.shape, [1, 1, 1]);
+        assert_eq!(
+            coarse_at(&coarse, 0, 0, 0),
+            GRASS,
+            "surface block must win so distant hills keep their surface texture"
+        );
+    }
+
+    #[test]
+    fn representative_prefers_blocks_without_isolated_faces() {
+        let mut fine = FineChunk::new([2, 2, 2]);
+        fine.set(0, 0, 0, STONE);
+        fine.set(0, 1, 0, SIGN);
+
+        let coarse = fine.coarse(2, &test_registry());
+
+        assert_eq!(
+            coarse_at(&coarse, 0, 0, 0),
+            STONE,
+            "blocks with isolated faces must not represent a cell when a plain block exists"
+        );
+    }
+
+    #[test]
+    fn representative_strips_rotation_and_stage_bits() {
+        let mut fine = FineChunk::new([2, 2, 2]);
+        fine.set(0, 0, 0, STONE | (3 << 16) | (5 << 20) | (7 << 24));
+
+        let coarse = fine.coarse(2, &test_registry());
+
+        assert_eq!(coarse_at(&coarse, 0, 0, 0), STONE);
+    }
+
+    #[test]
+    fn plants_do_not_solidify_cells() {
+        let mut fine = FineChunk::new([2, 2, 2]);
+        fine.set(0, 0, 0, PLANT);
+        fine.set(1, 1, 1, PLANT);
+
+        let coarse = fine.coarse(2, &test_registry());
+
+        assert_eq!(
+            coarse_at(&coarse, 0, 0, 0),
+            AIR,
+            "plants are subpixel at LOD distance and must not become full cells"
+        );
+    }
+
+    #[test]
+    fn leaves_solidify_cells_without_outranking_opaque() {
+        let mut fine = FineChunk::new([4, 4, 4]);
+        fine.set(0, 0, 0, STONE);
+        fine.set(0, 3, 0, LEAVES);
+
+        let coarse = fine.coarse(4, &test_registry());
+        assert_eq!(
+            coarse_at(&coarse, 0, 0, 0),
+            STONE,
+            "opaque blocks must outrank see-through solids even below them (seam invariant)"
+        );
+
+        let mut canopy = FineChunk::new([2, 2, 2]);
+        canopy.set(0, 0, 0, LEAVES);
+        let coarse = canopy.coarse(2, &test_registry());
+        assert_eq!(coarse_at(&coarse, 0, 0, 0), LEAVES);
+    }
+
+    #[test]
+    fn lights_downsample_to_channel_maxima() {
+        let mut fine = FineChunk::new([2, 2, 2]);
+        let mut a = 0u32;
+        a = LightUtils::insert_sunlight(a, 15);
+        a = LightUtils::insert_red_light(a, 2);
+        let mut b = 0u32;
+        b = LightUtils::insert_red_light(b, 9);
+        b = LightUtils::insert_blue_light(b, 4);
+        fine.set_light(0, 1, 0, a);
+        fine.set_light(1, 0, 1, b);
+
+        let coarse = fine.coarse(2, &test_registry());
+
+        let light = coarse.lights[0];
+        assert_eq!(LightUtils::extract_sunlight(light), 15);
+        assert_eq!(LightUtils::extract_red_light(light), 9);
+        assert_eq!(LightUtils::extract_green_light(light), 0);
+        assert_eq!(LightUtils::extract_blue_light(light), 4);
+    }
+
+    #[test]
+    fn fluid_cells_encode_surface_height_in_stage_bits() {
+        let registry = test_registry();
+        let factor = 4usize;
+
+        // Water fills fine y in 0..=2 of a 4-tall cell: the true surface sits
+        // at 2 + 0.875 blocks, i.e. 0.71875 of the coarse cell.
+        let mut fine = FineChunk::new([4, 4, 4]);
+        for x in 0..4 {
+            for z in 0..4 {
+                for y in 0..3 {
+                    fine.set(x, y, z, WATER);
+                }
+            }
+        }
+
+        let coarse = fine.coarse(factor, &registry);
+        let raw = coarse_at(&coarse, 0, 0, 0);
+
+        assert_eq!(raw & 0xFFFF, WATER);
+        let stage = (raw >> 24) & 0xF;
+        let decoded_height = (FLUID_BASE_HEIGHT - stage as f32 * FLUID_STAGE_DROPOFF).max(0.1);
+        let target = (2.0 + FLUID_BASE_HEIGHT) / factor as f32;
+        assert!(
+            (decoded_height - target).abs() <= FLUID_STAGE_DROPOFF / 2.0 + 1e-4,
+            "decoded fluid height {decoded_height} must approximate the true fractional \
+             surface {target} so scaled water lines up with the full-detail water level"
+        );
+    }
+
+    #[test]
+    fn solid_cells_hide_contained_fluid() {
+        let mut fine = FineChunk::new([2, 2, 2]);
+        fine.set(0, 0, 0, WATER);
+        fine.set(1, 1, 1, STONE);
+
+        let coarse = fine.coarse(2, &test_registry());
+        assert_eq!(coarse_at(&coarse, 0, 0, 0), STONE);
+    }
+
+    /// Solidity must be monotonic across levels: a solid cell at level L maps
+    /// into a solid cell at level L+1. The full-detail seam proof relies on
+    /// this for opaque voxels, and it keeps LOD ring boundaries hole-free.
+    #[test]
+    fn downsampling_is_monotonic_across_levels() {
+        let registry = test_registry();
+        let mut fine = FineChunk::new([16, 32, 16]);
+        for x in 0..16i32 {
+            for z in 0..16i32 {
+                let height = test_height(x, z);
+                for y in 0..height {
+                    fine.set(x as usize, y, z as usize, STONE);
+                }
+                fine.set(x as usize, height, z as usize, GRASS);
+            }
+        }
+
+        let coarse_1 = fine.coarse(2, &registry);
+        let coarse_2 = fine.coarse(4, &registry);
+
+        for x in 0..coarse_1.shape[0] {
+            for y in 0..coarse_1.shape[1] {
+                for z in 0..coarse_1.shape[2] {
+                    if coarse_at(&coarse_1, x, y, z) != AIR {
+                        assert_ne!(
+                            coarse_at(&coarse_2, x / 2, y / 2, z / 2),
+                            AIR,
+                            "solid L1 cell ({x},{y},{z}) must stay solid at L2"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Axis-aligned rectangle coverage tracker over a fine-resolution grid on
+    /// one boundary plane. Quads are rasterized at block resolution.
+    struct PlaneCoverage {
+        cells: Vec<bool>,
+        height: usize,
+        depth: usize,
+    }
+
+    impl PlaneCoverage {
+        fn new(height: usize, depth: usize) -> Self {
+            Self {
+                cells: vec![false; height * depth],
+                height,
+                depth,
+            }
+        }
+
+        /// Rasterize the quads of `geometries` that lie exactly on the plane
+        /// `x == plane_x` (world coordinates, geometry offset by `offset`).
+        fn cover_from(&mut self, geometries: &[GeometryProtocol], offset: [f32; 3], plane_x: f32) {
+            for geometry in geometries {
+                let positions = &geometry.positions;
+                for quad in 0..positions.len() / 12 {
+                    let base = quad * 12;
+                    let corners: Vec<[f32; 3]> = (0..4)
+                        .map(|i| {
+                            [
+                                positions[base + i * 3] + offset[0],
+                                positions[base + i * 3 + 1] + offset[1],
+                                positions[base + i * 3 + 2] + offset[2],
+                            ]
+                        })
+                        .collect();
+
+                    if corners.iter().any(|c| (c[0] - plane_x).abs() > 1e-4) {
+                        continue;
+                    }
+
+                    let min_y = corners.iter().map(|c| c[1]).fold(f32::MAX, f32::min);
+                    let max_y = corners.iter().map(|c| c[1]).fold(f32::MIN, f32::max);
+                    let min_z = corners.iter().map(|c| c[2]).fold(f32::MAX, f32::min);
+                    let max_z = corners.iter().map(|c| c[2]).fold(f32::MIN, f32::max);
+
+                    for y in (min_y.round() as usize)..(max_y.round() as usize) {
+                        for z in (min_z.round() as usize)..(max_z.round() as usize) {
+                            if y < self.height && z < self.depth {
+                                self.cells[y * self.depth + z] = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fn is_covered(&self, y: usize, z: usize) -> bool {
+            self.cells[y * self.depth + z]
+        }
+    }
+
+    /// The closed-hull property: every solid border cell of a LOD chunk emits
+    /// its border wall, so the mesh is watertight regardless of neighbors.
+    #[test]
+    fn lod_mesh_is_a_closed_hull_at_chunk_borders() {
+        let registry = test_registry();
+        let size = 16usize;
+        let height = 32usize;
+        let factor = 2usize;
+
+        let mut fine = FineChunk::new([size, height, size]);
+        for x in 0..size as i32 {
+            for z in 0..size as i32 {
+                let column = test_height(x, z);
+                for y in 0..column {
+                    fine.set(x as usize, y, z as usize, STONE);
+                }
+                fine.set(x as usize, column, z as usize, GRASS);
+            }
+        }
+
+        let coarse = fine.coarse(factor, &registry);
+        let geometries = mesh_coarse_chunk(&coarse, factor, &registry);
+
+        let mut coverage = PlaneCoverage::new(height, size);
+        coverage.cover_from(&geometries, [0.0, 0.0, 0.0], 0.0);
+
+        for cy in 0..coarse.shape[1] {
+            for cz in 0..coarse.shape[2] {
+                if coarse_at(&coarse, 0, cy, cz) == AIR {
+                    continue;
+                }
+                for y in cy * factor..(cy + 1) * factor {
+                    for z in cz * factor..(cz + 1) * factor {
+                        assert!(
+                            coverage.is_covered(y, z),
+                            "solid border cell (0,{cy},{cz}) leaves fine cell (y={y},z={z}) \
+                             uncovered on the x=0 border wall — hull is not closed"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// THE seam test: a full-detail chunk meshed against its true neighbor,
+    /// next to that neighbor rendered as a LOD-1 closed hull. Every fine cell
+    /// of the shared boundary plane where the displayed occupancy flips
+    /// (full-detail solid on one side XOR displayed-coarse solid on the
+    /// other) must be covered by geometry from at least one side; otherwise
+    /// a viewer could see into a solid volume's interior — a crack.
+    #[test]
+    fn full_detail_to_lod_boundary_is_watertight() {
+        let registry = test_registry();
+        let size = 16usize;
+        let height = 32usize;
+        let factor = 2usize;
+
+        // Chunk A occupies x in 0..16, chunk B x in 16..32. The terrain
+        // crosses the boundary with height discontinuities in both
+        // directions, plus a water pond and a tree canopy near the border on
+        // the B side to exercise non-opaque paths.
+        let mut a = FineChunk::new([size, height, size]);
+        let mut b = FineChunk::new([size, height, size]);
+
+        for x in 0..(2 * size) as i32 {
+            for z in 0..size as i32 {
+                let column = test_height(x, z);
+                let (chunk, lx) = if (x as usize) < size {
+                    (&mut a, x as usize)
+                } else {
+                    (&mut b, x as usize - size)
+                };
+                for y in 0..column {
+                    chunk.set(lx, y, z as usize, STONE);
+                }
+                chunk.set(lx, column, z as usize, GRASS);
+            }
+        }
+
+        for z in 4..8usize {
+            b.set(0, test_height(16, z as i32) + 1, z, WATER);
+        }
+        for z in 10..13usize {
+            b.set(1, 14, z, LEAVES);
+            b.set(0, 15, z, LEAVES);
+        }
+
+        // Full-detail mesh of A against B's true voxels (exactly what the
+        // engine produces for the outermost full-detail ring's inner chunks).
+        let a_data = ChunkData {
+            voxels: a.voxels.clone(),
+            lights: a.lights.clone(),
+            shape: a.shape,
+            min: [0, 0, 0],
+        };
+        let b_data = ChunkData {
+            voxels: b.voxels.clone(),
+            lights: b.lights.clone(),
+            shape: b.shape,
+            min: [size as i32, 0, 0],
+        };
+
+        let mut chunks: Vec<Option<ChunkData>> = (0..9).map(|_| None).collect();
+        chunks[4] = Some(a_data);
+        chunks[5] = Some(b_data);
+        let space = VoxelSpace::new(&chunks, size as i32, [0, 0]);
+        let a_geometries = mesh_space_greedy(
+            &[0, 0, 0],
+            &[size as i32, height as i32, size as i32],
+            &space,
+            &registry,
+        );
+
+        // LOD-1 closed hull of B.
+        let b_coarse = b.coarse(factor, &registry);
+        let b_geometries = mesh_coarse_chunk(&b_coarse, factor, &registry);
+
+        let plane_x = size as f32;
+        let mut coverage = PlaneCoverage::new(height, size);
+        coverage.cover_from(&a_geometries, [0.0, 0.0, 0.0], plane_x);
+        coverage.cover_from(&b_geometries, [size as f32, 0.0, 0.0], plane_x);
+
+        let opaque = |id: u32| -> bool {
+            registry
+                .get_block_by_id(id)
+                .map(|block| block.is_opaque)
+                .unwrap_or(false)
+        };
+
+        let mut checked = 0;
+        for y in 0..height {
+            for z in 0..size {
+                let a_solid = opaque(a.voxels[a.index(size - 1, y, z)] & 0xFFFF);
+                let b_display_solid = opaque(
+                    coarse_at(&b_coarse, 0, y / factor, z / factor) & 0xFFFF,
+                );
+
+                if a_solid != b_display_solid {
+                    checked += 1;
+                    assert!(
+                        coverage.is_covered(y, z),
+                        "boundary cell (y={y},z={z}) transitions solid<->air across the \
+                         full-detail/LOD seam but no geometry covers it — this is a crack"
+                    );
+                }
+            }
+        }
+
+        assert!(
+            checked > 20,
+            "expected a meaningful number of occupancy transitions on the test seam, got {checked}"
+        );
+    }
+
+    /// A second seam direction: LOD-1 chunk next to LOD-2 chunk. Both are
+    /// closed hulls; the coarser side's occupancy is a superset of the finer
+    /// side's (monotonicity), so every transition must again be covered.
+    #[test]
+    fn lod_to_lod_boundary_is_watertight() {
+        let registry = test_registry();
+        let size = 16usize;
+        let height = 32usize;
+
+        let mut a = FineChunk::new([size, height, size]);
+        let mut b = FineChunk::new([size, height, size]);
+        for x in 0..(2 * size) as i32 {
+            for z in 0..size as i32 {
+                let column = test_height(x, z);
+                let (chunk, lx) = if (x as usize) < size {
+                    (&mut a, x as usize)
+                } else {
+                    (&mut b, x as usize - size)
+                };
+                for y in 0..=column {
+                    chunk.set(lx, y, z as usize, STONE);
+                }
+            }
+        }
+
+        let a_coarse = a.coarse(2, &registry);
+        let b_coarse = b.coarse(4, &registry);
+        let a_geometries = mesh_coarse_chunk(&a_coarse, 2, &registry);
+        let b_geometries = mesh_coarse_chunk(&b_coarse, 4, &registry);
+
+        let plane_x = size as f32;
+        let mut coverage = PlaneCoverage::new(height, size);
+        coverage.cover_from(&a_geometries, [0.0, 0.0, 0.0], plane_x);
+        coverage.cover_from(&b_geometries, [size as f32, 0.0, 0.0], plane_x);
+
+        let mut checked = 0;
+        for y in 0..height {
+            for z in 0..size {
+                let a_solid = coarse_at(&a_coarse, size / 2 - 1, y / 2, z / 2) != AIR;
+                let b_solid = coarse_at(&b_coarse, 0, y / 4, z / 4) != AIR;
+                if a_solid != b_solid {
+                    checked += 1;
+                    assert!(
+                        coverage.is_covered(y, z),
+                        "boundary cell (y={y},z={z}) transitions across the LOD1/LOD2 seam \
+                         but no geometry covers it — this is a crack"
+                    );
+                }
+            }
+        }
+        assert!(checked > 0, "test terrain must produce seam transitions");
+    }
+
+    #[test]
+    fn lod_positions_are_scaled_to_block_units() {
+        let registry = test_registry();
+        let mut fine = FineChunk::new([4, 4, 4]);
+        for x in 0..2 {
+            for y in 0..2 {
+                for z in 0..2 {
+                    fine.set(x, y, z, STONE);
+                }
+            }
+        }
+
+        let geometries = mesh_chunk_lod(&fine.voxels, &fine.lights, fine.shape, 1, &registry);
+
+        assert_eq!(geometries.len(), 1);
+        let positions = &geometries[0].positions;
+        assert!(!positions.is_empty());
+
+        let mut max_coord = f32::MIN;
+        let mut min_coord = f32::MAX;
+        for value in positions {
+            max_coord = max_coord.max(*value);
+            min_coord = min_coord.min(*value);
+        }
+        assert_eq!(min_coord, 0.0);
+        assert_eq!(
+            max_coord, 2.0,
+            "a single coarse cell at LOD 1 must span exactly 2 blocks"
+        );
+        assert_eq!(geometries[0].voxel, STONE);
+    }
+
+    /// Water surfaces must stay flat at chunk borders in closed hulls: the
+    /// void outside the chunk is a continuation, not air, so corner heights
+    /// must not droop toward the border.
+    #[test]
+    fn lod_water_surface_stays_flat_at_chunk_borders() {
+        let registry = test_registry();
+        let size = 8usize;
+        let height = 8usize;
+
+        let mut fine = FineChunk::new([size, height, size]);
+        for x in 0..size {
+            for z in 0..size {
+                fine.set(x, 0, z, STONE);
+                for y in 1..4 {
+                    fine.set(x, y, z, WATER);
+                }
+            }
+        }
+
+        let geometries = mesh_chunk_lod(&fine.voxels, &fine.lights, fine.shape, 1, &registry);
+
+        let water_geometry = geometries
+            .iter()
+            .find(|geometry| geometry.voxel == WATER)
+            .expect("LOD mesh must contain water geometry");
+
+        // Collect the highest vertex of every water column: the top surface.
+        // All of them — including the chunk-border ones — must sit near the
+        // encoded surface height, with no 0.1-cell droop at borders.
+        let mut top_heights: Vec<f32> = Vec::new();
+        for quad in 0..water_geometry.positions.len() / 12 {
+            for corner in 0..4 {
+                let y = water_geometry.positions[quad * 12 + corner * 3 + 1];
+                if y > 3.0 {
+                    top_heights.push(y);
+                }
+            }
+        }
+
+        assert!(!top_heights.is_empty(), "water surface must be meshed");
+        let min_top = top_heights.iter().fold(f32::MAX, |a, &b| a.min(b));
+        let max_top = top_heights.iter().fold(f32::MIN, |a, &b| a.max(b));
+        assert!(
+            max_top - min_top < 0.05,
+            "water surface must be flat across the whole LOD chunk including borders, \
+             got min {min_top} max {max_top}"
+        );
+    }
+
+    #[test]
+    fn mesh_config_default_unchanged() {
+        assert_eq!(MeshConfig::default().chunk_size, 16);
+    }
+}

--- a/crates/mesher/src/lod.rs
+++ b/crates/mesher/src/lod.rs
@@ -36,12 +36,81 @@
 //! LOD chunks are distant by definition, so the overdraw is negligible next
 //! to the correctness guarantee.
 
-use voxelize_core::LightUtils;
+use voxelize_core::{BlockRotation, LightColor, LightUtils, VoxelAccess};
 
 use crate::mesher::{
     mesh_space_greedy, ChunkData, GeometryProtocol, Registry, VoxelSpace, FLUID_BASE_HEIGHT,
     FLUID_STAGE_DROPOFF,
 };
+
+/// Full sunlight, baked into light samples that fall outside the chunk being
+/// LOD-meshed (see [`SkyLitLodSpace`]).
+const VOID_SUNLIGHT: u32 = 15;
+
+/// The isolated coarse space a LOD hull is meshed in, with one lighting
+/// twist: out-of-chunk light samples read as fully sunlit instead of black.
+///
+/// Closed hulls expose walls wherever the displayed neighbor terrain is
+/// lower — walls that face open sky at display time. Their light samples,
+/// however, would come from the void (zero) and from the chunk's own
+/// underground cells (also zero), baking the exposed wall pitch black. Sky
+/// lighting the void matches what those walls actually face. Occupancy is
+/// untouched: `contains` still reports the void, so hull geometry (and the
+/// fluid void-face suppression) behave exactly as before, and interior faces
+/// whose samples stay in-chunk keep their real darkness.
+struct SkyLitLodSpace<'a> {
+    inner: VoxelSpace<'a>,
+}
+
+impl<'a> VoxelAccess for SkyLitLodSpace<'a> {
+    fn get_voxel(&self, vx: i32, vy: i32, vz: i32) -> u32 {
+        self.inner.get_voxel(vx, vy, vz)
+    }
+
+    fn get_raw_voxel(&self, vx: i32, vy: i32, vz: i32) -> u32 {
+        self.inner.get_raw_voxel(vx, vy, vz)
+    }
+
+    fn get_voxel_rotation(&self, vx: i32, vy: i32, vz: i32) -> BlockRotation {
+        self.inner.get_voxel_rotation(vx, vy, vz)
+    }
+
+    fn get_voxel_stage(&self, vx: i32, vy: i32, vz: i32) -> u32 {
+        self.inner.get_voxel_stage(vx, vy, vz)
+    }
+
+    fn get_sunlight(&self, vx: i32, vy: i32, vz: i32) -> u32 {
+        if !self.inner.contains(vx, vy, vz) {
+            return VOID_SUNLIGHT;
+        }
+        self.inner.get_sunlight(vx, vy, vz)
+    }
+
+    fn get_torch_light(&self, vx: i32, vy: i32, vz: i32, color: LightColor) -> u32 {
+        if !self.inner.contains(vx, vy, vz) {
+            return match color {
+                LightColor::Sunlight => VOID_SUNLIGHT,
+                _ => 0,
+            };
+        }
+        self.inner.get_torch_light(vx, vy, vz, color)
+    }
+
+    fn get_all_lights(&self, vx: i32, vy: i32, vz: i32) -> (u32, u32, u32, u32) {
+        if !self.inner.contains(vx, vy, vz) {
+            return (VOID_SUNLIGHT, 0, 0, 0);
+        }
+        self.inner.get_all_lights(vx, vy, vz)
+    }
+
+    fn get_max_height(&self, vx: i32, vz: i32) -> u32 {
+        self.inner.get_max_height(vx, vz)
+    }
+
+    fn contains(&self, vx: i32, vy: i32, vz: i32) -> bool {
+        self.inner.contains(vx, vy, vz)
+    }
+}
 
 /// Downsampled stand-in for one coarse cell, chosen from the fine voxels the
 /// cell contains.
@@ -307,7 +376,8 @@ pub fn mesh_coarse_chunk(
 
     // A single-chunk neighborhood: only the center slot is populated, so the
     // space reports `contains() == false` for every out-of-chunk coordinate
-    // and the mesher emits the closed border walls.
+    // and the mesher emits the closed border walls (sky-lit, see
+    // [`SkyLitLodSpace`]).
     let mut chunks: Vec<Option<ChunkData>> = (0..9).map(|_| None).collect();
     chunks[4] = Some(ChunkData {
         voxels: coarse.voxels.clone(),
@@ -316,7 +386,9 @@ pub fn mesh_coarse_chunk(
         min: [0, 0, 0],
     });
 
-    let space = VoxelSpace::new(&chunks, cs_x as i32, [0, 0]);
+    let space = SkyLitLodSpace {
+        inner: VoxelSpace::new(&chunks, cs_x as i32, [0, 0]),
+    };
 
     let min = [0, 0, 0];
     let max = [cs_x as i32, cs_y as i32, cs_z as i32];
@@ -1045,6 +1117,120 @@ mod tests {
             "a single coarse cell at LOD 1 must span exactly 2 blocks"
         );
         assert_eq!(geometries[0].voxel, STONE);
+    }
+
+    /// Fluid faces must never be emitted against the void: between adjacent
+    /// water hulls both sides would emit full-height interior walls that are
+    /// all visible through the transparent surface (stacking into an opaque,
+    /// dark mass), and at data horizons the opaque hull behind them already
+    /// closes the silhouette.
+    #[test]
+    fn lod_water_emits_no_hull_border_walls() {
+        let registry = test_registry();
+        let size = 8usize;
+        let height = 8usize;
+        let factor = 2usize;
+
+        let mut fine = FineChunk::new([size, height, size]);
+        for x in 0..size {
+            for z in 0..size {
+                fine.set(x, 0, z, STONE);
+                for y in 1..4 {
+                    fine.set(x, y, z, WATER);
+                }
+            }
+        }
+
+        let geometries = mesh_chunk_lod(&fine.voxels, &fine.lights, fine.shape, 1, &registry);
+        let water_geometry = geometries
+            .iter()
+            .find(|geometry| geometry.voxel == WATER)
+            .expect("water surface must still be meshed");
+
+        let border = size as f32;
+        for quad in 0..water_geometry.positions.len() / 12 {
+            for axis in [0usize, 2usize] {
+                for plane in [0.0f32, border] {
+                    let is_wall_on_plane = (0..4).all(|corner| {
+                        let value = water_geometry.positions[quad * 12 + corner * 3 + axis];
+                        (value - plane).abs() < 0.01
+                    });
+                    assert!(
+                        !is_wall_on_plane,
+                        "water quad {quad} sits on the hull border plane (axis {axis} at \
+                         {plane}) — fluid faces must not be emitted against the void"
+                    );
+                }
+            }
+        }
+
+        let solid_geometry = geometries
+            .iter()
+            .find(|geometry| geometry.voxel == STONE)
+            .expect("hull floor must be meshed");
+        let has_border_wall = (0..solid_geometry.positions.len() / 12).any(|quad| {
+            (0..4).all(|corner| {
+                solid_geometry.positions[quad * 12 + corner * 3].abs() < 0.01
+            })
+        });
+        assert!(
+            has_border_wall,
+            "opaque hull border walls must remain closed — only fluids skip the void"
+        );
+    }
+
+    /// Hull walls face open sky at display time, so their baked light must
+    /// come from the sky-lit void, not from the chunk's dark underground
+    /// cells — otherwise every exposed LOD cliff fades to black.
+    #[test]
+    fn lod_hull_walls_are_sky_lit() {
+        let registry = test_registry();
+        let size = 8usize;
+        let height = 16usize;
+
+        let mut fine = FineChunk::new([size, height, size]);
+        let mut sunlit = 0u32;
+        sunlit = LightUtils::insert_sunlight(sunlit, 15);
+        for x in 0..size {
+            for z in 0..size {
+                for y in 0..6 {
+                    fine.set(x, y, z, STONE);
+                }
+                for y in 6..height {
+                    fine.set_light(x, y, z, sunlit);
+                }
+            }
+        }
+
+        let geometries = mesh_chunk_lod(&fine.voxels, &fine.lights, fine.shape, 1, &registry);
+        let geometry = geometries
+            .iter()
+            .find(|geometry| geometry.voxel == STONE)
+            .expect("terrain must be meshed");
+
+        let mut wall_vertices = 0;
+        for quad in 0..geometry.positions.len() / 12 {
+            let is_border_wall = (0..4).all(|corner| {
+                geometry.positions[quad * 12 + corner * 3].abs() < 0.01
+            });
+            if !is_border_wall {
+                continue;
+            }
+            for corner in 0..4 {
+                wall_vertices += 1;
+                let packed = geometry.lights[quad * 4 + corner] as u32;
+                let sunlight = LightUtils::extract_sunlight(packed & 0xFFFF);
+                assert!(
+                    sunlight >= 10,
+                    "hull border wall vertex must be sky-lit, got sunlight {sunlight}"
+                );
+            }
+        }
+
+        assert!(
+            wall_vertices > 0,
+            "test terrain must produce hull border walls on the x=0 plane"
+        );
     }
 
     /// Water surfaces must stay flat at chunk borders in closed hulls: the

--- a/crates/mesher/src/lod.rs
+++ b/crates/mesher/src/lod.rs
@@ -43,64 +43,117 @@ use crate::mesher::{
     FLUID_STAGE_DROPOFF,
 };
 
-/// Full sunlight, baked into light samples that fall outside the chunk being
-/// LOD-meshed (see [`SkyLitLodSpace`]).
-const VOID_SUNLIGHT: u32 = 15;
-
-/// The isolated coarse space a LOD hull is meshed in, with one lighting
-/// twist: out-of-chunk light samples read as fully sunlit instead of black.
+/// The isolated coarse space a LOD hull is meshed in, with the void treated
+/// as a *continuation of the chunk's own edge* for everything the mesher
+/// samples but does not build geometry from.
 ///
-/// Closed hulls expose walls wherever the displayed neighbor terrain is
-/// lower — walls that face open sky at display time. Their light samples,
-/// however, would come from the void (zero) and from the chunk's own
-/// underground cells (also zero), baking the exposed wall pitch black. Sky
-/// lighting the void matches what those walls actually face. Occupancy is
-/// untouched: `contains` still reports the void, so hull geometry (and the
-/// fluid void-face suppression) behave exactly as before, and interior faces
-/// whose samples stay in-chunk keep their real darkness.
-struct SkyLitLodSpace<'a> {
+/// Occupancy is untouched — `contains` still reports the void, so hull
+/// border walls emit and fluids skip their void faces exactly as before.
+/// What changes is what out-of-chunk *samples* return:
+///
+/// - **Voxels** mirror the nearest in-chunk cell (clamp-to-edge), so ambient
+///   occlusion at border cells darkens like the equivalent interior corner
+///   instead of reading the void as permanently open air.
+/// - **Light** returns the border column's *surface light* — the light
+///   resting directly above the column's topmost solid cell. That is the
+///   best single approximation of the neighbor's open-air light profile:
+///   full sunlight over open land (exposed hull cliffs stay lit — the
+///   original black-wall bug), attenuated water light over the sea floor,
+///   and dim light in shaded valleys. A constant "sky" value here is what
+///   painted a bright lattice along every LOD chunk seam wherever real
+///   local light was below maximum (underwater, shaded slopes): border-face
+///   corners averaged the constant into their samples and rendered brighter
+///   than the interior one cell away.
+struct EdgeLitLodSpace<'a> {
     inner: VoxelSpace<'a>,
+    shape: [i32; 3],
+    /// Per-column packed light (`shape.x * shape.z`, row-major x then z) of
+    /// the cell sitting on the column's topmost solid cell.
+    surface_lights: Vec<u32>,
 }
 
-impl<'a> VoxelAccess for SkyLitLodSpace<'a> {
+impl<'a> EdgeLitLodSpace<'a> {
+    fn new(inner: VoxelSpace<'a>, coarse: &ChunkData, registry: &Registry) -> Self {
+        Self {
+            inner,
+            shape: [
+                coarse.shape[0] as i32,
+                coarse.shape[1] as i32,
+                coarse.shape[2] as i32,
+            ],
+            surface_lights: compute_surface_lights(coarse, registry),
+        }
+    }
+
+    #[inline]
+    fn clamped(&self, vx: i32, vy: i32, vz: i32) -> (i32, i32, i32) {
+        (
+            vx.clamp(0, self.shape[0] - 1),
+            vy.clamp(0, self.shape[1] - 1),
+            vz.clamp(0, self.shape[2] - 1),
+        )
+    }
+
+    #[inline]
+    fn surface_light(&self, vx: i32, vz: i32) -> u32 {
+        let x = vx.clamp(0, self.shape[0] - 1) as usize;
+        let z = vz.clamp(0, self.shape[2] - 1) as usize;
+        self.surface_lights[x * self.shape[2] as usize + z]
+    }
+}
+
+impl<'a> VoxelAccess for EdgeLitLodSpace<'a> {
     fn get_voxel(&self, vx: i32, vy: i32, vz: i32) -> u32 {
-        self.inner.get_voxel(vx, vy, vz)
+        if self.inner.contains(vx, vy, vz) {
+            return self.inner.get_voxel(vx, vy, vz);
+        }
+        let (cx, cy, cz) = self.clamped(vx, vy, vz);
+        self.inner.get_voxel(cx, cy, cz)
     }
 
     fn get_raw_voxel(&self, vx: i32, vy: i32, vz: i32) -> u32 {
-        self.inner.get_raw_voxel(vx, vy, vz)
+        if self.inner.contains(vx, vy, vz) {
+            return self.inner.get_raw_voxel(vx, vy, vz);
+        }
+        let (cx, cy, cz) = self.clamped(vx, vy, vz);
+        self.inner.get_raw_voxel(cx, cy, cz)
     }
 
     fn get_voxel_rotation(&self, vx: i32, vy: i32, vz: i32) -> BlockRotation {
-        self.inner.get_voxel_rotation(vx, vy, vz)
+        let (cx, cy, cz) = self.clamped(vx, vy, vz);
+        self.inner.get_voxel_rotation(cx, cy, cz)
     }
 
     fn get_voxel_stage(&self, vx: i32, vy: i32, vz: i32) -> u32 {
-        self.inner.get_voxel_stage(vx, vy, vz)
+        let (cx, cy, cz) = self.clamped(vx, vy, vz);
+        self.inner.get_voxel_stage(cx, cy, cz)
     }
 
     fn get_sunlight(&self, vx: i32, vy: i32, vz: i32) -> u32 {
-        if !self.inner.contains(vx, vy, vz) {
-            return VOID_SUNLIGHT;
+        if self.inner.contains(vx, vy, vz) {
+            return self.inner.get_sunlight(vx, vy, vz);
         }
-        self.inner.get_sunlight(vx, vy, vz)
+        LightUtils::extract_sunlight(self.surface_light(vx, vz))
     }
 
     fn get_torch_light(&self, vx: i32, vy: i32, vz: i32, color: LightColor) -> u32 {
-        if !self.inner.contains(vx, vy, vz) {
-            return match color {
-                LightColor::Sunlight => VOID_SUNLIGHT,
-                _ => 0,
-            };
+        if self.inner.contains(vx, vy, vz) {
+            return self.inner.get_torch_light(vx, vy, vz, color);
         }
-        self.inner.get_torch_light(vx, vy, vz, color)
+        let light = self.surface_light(vx, vz);
+        match color {
+            LightColor::Sunlight => LightUtils::extract_sunlight(light),
+            LightColor::Red => LightUtils::extract_red_light(light),
+            LightColor::Green => LightUtils::extract_green_light(light),
+            LightColor::Blue => LightUtils::extract_blue_light(light),
+        }
     }
 
     fn get_all_lights(&self, vx: i32, vy: i32, vz: i32) -> (u32, u32, u32, u32) {
-        if !self.inner.contains(vx, vy, vz) {
-            return (VOID_SUNLIGHT, 0, 0, 0);
+        if self.inner.contains(vx, vy, vz) {
+            return self.inner.get_all_lights(vx, vy, vz);
         }
-        self.inner.get_all_lights(vx, vy, vz)
+        LightUtils::extract_all(self.surface_light(vx, vz))
     }
 
     fn get_max_height(&self, vx: i32, vz: i32) -> u32 {
@@ -110,6 +163,43 @@ impl<'a> VoxelAccess for SkyLitLodSpace<'a> {
     fn contains(&self, vx: i32, vy: i32, vz: i32) -> bool {
         self.inner.contains(vx, vy, vz)
     }
+}
+
+/// For every coarse column, the packed light of the cell resting on the
+/// column's topmost solid (non-empty, non-fluid) cell: full sunlight over
+/// open ground, attenuated water light over a submerged floor, dim light
+/// under overhangs. Columns with no solid cell (or solid to the ceiling)
+/// fall back to their topmost cell's light.
+fn compute_surface_lights(coarse: &ChunkData, registry: &Registry) -> Vec<u32> {
+    let [size_x, size_y, size_z] = coarse.shape;
+    let mut surface_lights = vec![0u32; size_x * size_z];
+
+    for x in 0..size_x {
+        for z in 0..size_z {
+            let column = x * size_y * size_z + z;
+            let index_of = |y: usize| column + y * size_z;
+
+            let mut surface_y = size_y - 1;
+            for y in (0..size_y).rev() {
+                let id = coarse.voxels[index_of(y)] & 0xFFFF;
+                if id == 0 {
+                    continue;
+                }
+                let is_solid = registry
+                    .get_block_by_id(id)
+                    .map(|block| !block.is_empty && !block.is_fluid)
+                    .unwrap_or(false);
+                if is_solid {
+                    surface_y = (y + 1).min(size_y - 1);
+                    break;
+                }
+            }
+
+            surface_lights[x * size_z + z] = coarse.lights[index_of(surface_y)];
+        }
+    }
+
+    surface_lights
 }
 
 /// Downsampled stand-in for one coarse cell, chosen from the fine voxels the
@@ -376,8 +466,8 @@ pub fn mesh_coarse_chunk(
 
     // A single-chunk neighborhood: only the center slot is populated, so the
     // space reports `contains() == false` for every out-of-chunk coordinate
-    // and the mesher emits the closed border walls (sky-lit, see
-    // [`SkyLitLodSpace`]).
+    // and the mesher emits the closed border walls (edge-lit, see
+    // [`EdgeLitLodSpace`]).
     let mut chunks: Vec<Option<ChunkData>> = (0..9).map(|_| None).collect();
     chunks[4] = Some(ChunkData {
         voxels: coarse.voxels.clone(),
@@ -386,9 +476,7 @@ pub fn mesh_coarse_chunk(
         min: [0, 0, 0],
     });
 
-    let space = SkyLitLodSpace {
-        inner: VoxelSpace::new(&chunks, cs_x as i32, [0, 0]),
-    };
+    let space = EdgeLitLodSpace::new(VoxelSpace::new(&chunks, cs_x as i32, [0, 0]), coarse, registry);
 
     let min = [0, 0, 0];
     let max = [cs_x as i32, cs_y as i32, cs_z as i32];
@@ -1179,11 +1267,59 @@ mod tests {
         );
     }
 
-    /// Hull walls face open sky at display time, so their baked light must
-    /// come from the sky-lit void, not from the chunk's dark underground
-    /// cells — otherwise every exposed LOD cliff fades to black.
+    /// Border lighting must be continuous with the interior: with uniformly
+    /// dim light (e.g. under water or in shade), border-face corners must
+    /// not brighten from out-of-chunk samples. A constant "sky" void light
+    /// did exactly that — averaging full sunlight into every border corner —
+    /// which painted a bright lattice along every LOD chunk seam.
     #[test]
-    fn lod_hull_walls_are_sky_lit() {
+    fn lod_border_lighting_matches_interior_in_dim_light() {
+        let registry = test_registry();
+        let size = 8usize;
+        let height = 8usize;
+
+        let mut fine = FineChunk::new([size, height, size]);
+        let mut dim = 0u32;
+        dim = LightUtils::insert_sunlight(dim, 9);
+        for x in 0..size {
+            for z in 0..size {
+                for y in 0..3 {
+                    fine.set(x, y, z, STONE);
+                }
+                for y in 3..height {
+                    fine.set_light(x, y, z, dim);
+                }
+            }
+        }
+
+        let geometries = mesh_chunk_lod(&fine.voxels, &fine.lights, fine.shape, 1, &registry);
+        let geometry = geometries
+            .iter()
+            .find(|geometry| geometry.voxel == STONE)
+            .expect("terrain must be meshed");
+
+        let mut max_sunlight = 0;
+        for packed in &geometry.lights {
+            let sunlight = LightUtils::extract_sunlight(*packed as u32 & 0xFFFF);
+            assert!(
+                sunlight <= 9,
+                "no vertex may exceed the ambient light level: border faces must \
+                 light like the interior, got sunlight {sunlight}"
+            );
+            max_sunlight = max_sunlight.max(sunlight);
+        }
+        assert_eq!(
+            max_sunlight, 9,
+            "faces exposed to the dim air must carry its light level"
+        );
+    }
+
+    /// Hull walls face the neighbor's open air at display time, so their
+    /// baked light must come from the border column's surface light — full
+    /// sunlight over open land — not from the chunk's dark underground
+    /// cells, otherwise every exposed LOD cliff fades to black.
+    #[test]
+    fn lod_hull_walls_are_surface_lit() {
         let registry = test_registry();
         let size = 8usize;
         let height = 16usize;

--- a/crates/mesher/src/mesher.rs
+++ b/crates/mesher/src/mesher.rs
@@ -1013,6 +1013,15 @@ fn should_render_face<S: VoxelAccess>(
     let neighbor_id = space.get_voxel(nvx, nvy, nvz);
     let n_is_void = !space.contains(nvx, nvy, nvz);
 
+    // Fluids never face the void. Out-of-space is unknown terrain, not air:
+    // a fluid wall there is either duplicated by the neighboring mesh (and,
+    // being transparent, visibly stacks instead of being occluded) or faces
+    // a data horizon where the opaque hull behind it already closes the
+    // silhouette. Suppressing these keeps LOD water a single clean surface.
+    if is_fluid && n_is_void {
+        return false;
+    }
+
     if !n_is_void && !registry.has_type(neighbor_id) {
         return false;
     }
@@ -1707,6 +1716,11 @@ fn process_face<S: VoxelAccess>(
 
     let neighbor_id = space.get_voxel(nvx, nvy, nvz);
     let n_is_void = !space.contains(nvx, nvy, nvz);
+
+    // Mirrors `should_render_face`: fluids never face the void (see there).
+    if is_fluid && n_is_void {
+        return;
+    }
 
     if !n_is_void && !registry.has_type(neighbor_id) {
         return;

--- a/crates/mesher/src/mesher.rs
+++ b/crates/mesher/src/mesher.rs
@@ -161,8 +161,8 @@ pub const VOXEL_NEIGHBORS: [[i32; 3]; 6] = [
     [0, 0, -1],
 ];
 
-const FLUID_BASE_HEIGHT: f32 = 0.875;
-const FLUID_STAGE_DROPOFF: f32 = 0.1;
+pub(crate) const FLUID_BASE_HEIGHT: f32 = 0.875;
+pub(crate) const FLUID_STAGE_DROPOFF: f32 = 0.1;
 const FLUID_SURFACE_OFFSET: f32 = 0.005;
 
 struct NeighborCache {
@@ -281,14 +281,18 @@ pub struct MeshOutput {
     pub geometries: Vec<GeometryProtocol>,
 }
 
-struct VoxelSpace<'a> {
+pub(crate) struct VoxelSpace<'a> {
     chunks: &'a [Option<ChunkData>],
     chunk_size: i32,
     center_coords: [i32; 2],
 }
 
 impl<'a> VoxelSpace<'a> {
-    fn new(chunks: &'a [Option<ChunkData>], chunk_size: i32, center_coords: [i32; 2]) -> Self {
+    pub(crate) fn new(
+        chunks: &'a [Option<ChunkData>],
+        chunk_size: i32,
+        center_coords: [i32; 2],
+    ) -> Self {
         Self {
             chunks,
             chunk_size,
@@ -709,6 +713,14 @@ fn calculate_fluid_corner_height<S: VoxelAccess>(
     for [dx, dz] in corner_offsets {
         let nx = vx + dx;
         let nz = vz + dz;
+
+        // Out-of-space neighbors are unknown terrain, not air: treat them as a
+        // fluid continuation (neutral) so surfaces stay flat at data borders
+        // instead of drooping toward the void. This keeps closed LOD hulls and
+        // horizon-edge chunks free of scalloped water rims.
+        if !space.contains(nx, vy, nz) {
+            continue;
+        }
 
         if has_fluid_above(nx, vy, nz, fluid_id, space) {
             total_height += 1.0;

--- a/crates/mesher/src/mesher.rs
+++ b/crates/mesher/src/mesher.rs
@@ -2225,12 +2225,19 @@ pub fn mesh_space_greedy<S: VoxelAccess>(
                     }
 
                     if block.is_opaque {
+                        // A voxel only counts as buried when every neighbor is
+                        // an in-space opaque voxel: out-of-space coordinates
+                        // are unknown terrain whose faces must still be
+                        // evaluated, regardless of what a space's `get_voxel`
+                        // reports for them (e.g. edge-mirrored LOD spaces).
                         let all_neighbors_opaque = VOXEL_NEIGHBORS.iter().all(|&[nx, ny, nz]| {
-                            let id = space.get_voxel(vx + nx, vy + ny, vz + nz);
-                            registry
-                                .get_block_by_id(id)
-                                .map(|b| b.is_opaque)
-                                .unwrap_or(false)
+                            space.contains(vx + nx, vy + ny, vz + nz) && {
+                                let id = space.get_voxel(vx + nx, vy + ny, vz + nz);
+                                registry
+                                    .get_block_by_id(id)
+                                    .map(|b| b.is_opaque)
+                                    .unwrap_or(false)
+                            }
                         });
                         if all_neighbors_opaque {
                             continue;

--- a/examples/client/src/main.ts
+++ b/examples/client/src/main.ts
@@ -30,8 +30,14 @@ const canvas = document.getElementById("main") as HTMLCanvasElement;
 /* -------------------------------------------------------------------------- */
 /*                               VOXELIZE WORLD                               */
 /* -------------------------------------------------------------------------- */
+const isLodDisabled =
+  new URLSearchParams(window.location.search).get("noLod") === "1";
+
+let worldUpdateMs = 0;
+
 const world = new VOXELIZE.World({
   textureUnitDimension: 8,
+  isLodEnabled: !isLodDisabled,
 });
 // actual world setup code handled later after network and world are initialized
 
@@ -656,6 +662,28 @@ debug.registerDisplay("# of points", () => {
   return renderer.info.render.points;
 });
 
+debug.registerDisplay("# of draw calls", () => {
+  return renderer.info.render.calls;
+});
+
+debug.registerDisplay("World update (ms)", () => {
+  return worldUpdateMs.toFixed(2);
+});
+
+let fpsFrameCount = 0;
+let fpsWindowStart = performance.now();
+let fpsValue = 0;
+debug.registerDisplay("FPS", () => {
+  fpsFrameCount++;
+  const now = performance.now();
+  if (now - fpsWindowStart >= 1000) {
+    fpsValue = Math.round((fpsFrameCount * 1000) / (now - fpsWindowStart));
+    fpsFrameCount = 0;
+    fpsWindowStart = now;
+  }
+  return fpsValue;
+});
+
 debug.registerDisplay("Concurrent WebWorkers", () => {
   return VOXELIZE.WorkerPool.WORKING_COUNT;
 });
@@ -1100,10 +1128,12 @@ const update = () => {
 
   world.chunkRenderer.uniforms.fogColor.value.lerp(fogColor, 0.08);
 
+  const worldUpdateStart = performance.now();
   world.update(
     controls.object.position,
     camera.getWorldDirection(new THREE.Vector3()),
   );
+  worldUpdateMs = performance.now() - worldUpdateStart;
 
   entities.update();
 
@@ -1120,9 +1150,17 @@ const overlayEffect = new VOXELIZE.BlockOverlayEffect(world, camera);
 overlayEffect.addOverlay("water", new THREE.Color("#5F9DF7"), 0.001);
 composer.addPass(new EffectPass(camera, new SMAAEffect({}), overlayEffect));
 
+// Accumulate renderer.info across every composer pass of a frame so the
+// debug panel reports whole-frame draw calls/triangles; the reset happens
+// here once per frame instead of inside each render() call.
+renderer.info.autoReset = false;
+
 const animate = () => {
   requestAnimationFrame(animate);
+  // The debug panel (inside update) reads the previous frame's accumulated
+  // totals; reset just before this frame's passes begin.
   if (isFocused) update();
+  renderer.info.reset();
   composer.render();
   renderer.clearDepth();
   renderer.render(armScene, armCamera);

--- a/examples/server/worlds/terrain/mod.rs
+++ b/examples/server/worlds/terrain/mod.rs
@@ -4,8 +4,8 @@ use noise::{Curve, Fbm, HybridMulti, MultiFractal, NoiseFn, Perlin, ScaleBias};
 use serde::{Deserialize, Serialize};
 use std::f64;
 use voxelize::{
-    Biome, Chunk, ChunkStage, KdTree, LSystem, NoiseOptions, Resources, SeededNoise, Space,
-    Terrain, TerrainLayer, Tree, Trees, Vec3, VoxelAccess, World, WorldConfig,
+    Biome, Chunk, ChunkLodConfig, ChunkStage, KdTree, LSystem, NoiseOptions, Resources,
+    SeededNoise, Space, Terrain, TerrainLayer, Tree, Trees, Vec3, VoxelAccess, World, WorldConfig,
 };
 
 use super::shared::{
@@ -146,6 +146,9 @@ pub fn setup_terrain_world() -> World {
         .default_time(1200.0)
         .time_per_day(2400)
         .seed(999)
+        // Opt into distant-chunk LOD: clients render chunks beyond their
+        // render radius R as reduced-detail meshes, out to R * 2^max_level.
+        .chunk_lod(Some(ChunkLodConfig { max_level: 2 }))
         .build();
 
     let mut world = World::new("terrain", &config);

--- a/messages.proto
+++ b/messages.proto
@@ -14,6 +14,11 @@ message Geometry {
 message Mesh {
   int32 level = 1;
   repeated Geometry geometries = 2;
+
+  // Level of detail this mesh was built at. 0 (default) is a full-detail
+  // sub-chunk mesh; L >= 1 is a whole-column chunk mesh downsampled by 2^L
+  // (see server/world/generators/mesher.rs and crates/mesher/src/lod.rs).
+  uint32 lod = 3;
 }
 
 message Chunk {

--- a/packages/core/src/core/world/chunk-lod.test.ts
+++ b/packages/core/src/core/world/chunk-lod.test.ts
@@ -73,17 +73,17 @@ describe("resolveLodTarget hysteresis", () => {
 
 describe("lod regions", () => {
   it("doubles region side with level for constant per-ring draw calls", () => {
-    expect(lodRegionSideInChunks(1)).toBe(4);
-    expect(lodRegionSideInChunks(2)).toBe(8);
-    expect(lodRegionSideInChunks(3)).toBe(16);
+    expect(lodRegionSideInChunks(1)).toBe(8);
+    expect(lodRegionSideInChunks(2)).toBe(16);
+    expect(lodRegionSideInChunks(3)).toBe(32);
   });
 
   it("buckets chunk coords into level-scoped regions", () => {
     expect(lodRegionKey(0, 0, 1)).toBe("1|0,0");
-    expect(lodRegionKey(3, 3, 1)).toBe("1|0,0");
-    expect(lodRegionKey(4, 0, 1)).toBe("1|1,0");
+    expect(lodRegionKey(7, 7, 1)).toBe("1|0,0");
+    expect(lodRegionKey(8, 0, 1)).toBe("1|1,0");
     expect(lodRegionKey(-1, -1, 1)).toBe("1|-1,-1");
-    expect(lodRegionKey(4, 0, 2)).toBe("2|0,0");
+    expect(lodRegionKey(8, 0, 2)).toBe("2|0,0");
   });
 });
 
@@ -131,15 +131,24 @@ function makeHost(overrides: Partial<LodChunkManagerHost> = {}): {
 
 function makeManager(
   overrides: Partial<LodChunkManagerHost> = {},
-  maxLodLevel = 2,
+  options: Partial<{
+    maxLodLevel: number;
+    maxRegionRebuildsPerUpdate: number;
+    regionRebuildCooldown: number;
+  }> = {},
 ) {
   const { host, log } = makeHost(overrides);
   const manager = new LodChunkManager(host, {
-    maxLodLevel,
+    maxLodLevel: 2,
     hysteresis: 1,
     maxRequestsPerUpdate: 512,
     rerequestInterval: 300,
     maxLodRadius: 96,
+    // Unthrottled by default so single-update expectations stay simple; the
+    // budget and cooldown behaviors have dedicated tests.
+    maxRegionRebuildsPerUpdate: 64,
+    regionRebuildCooldown: 0,
+    ...options,
   });
   return { manager, log };
 }
@@ -367,5 +376,95 @@ describe("LodChunkManager", () => {
     manager.update([0, 0]);
     expect(manager.owns(0, 0)).toBe(false);
     expect(manager.owns(2, 2)).toBe(false);
+  });
+});
+
+describe("LodChunkManager rebuild throttling", () => {
+  const countMeshes = (manager: LodChunkManager) => {
+    let count = 0;
+    manager.group.traverse((object) => {
+      if ((object as Mesh).isMesh) count++;
+    });
+    return count;
+  };
+
+  it("rebuilds at most the budgeted number of regions per update, nearest first", () => {
+    const { manager } = makeManager({}, { maxRegionRebuildsPerUpdate: 1 });
+
+    manager.update([0, 0]);
+    // Two different level-1 regions: chunks at x=6 (region 0) and x=9
+    // (region 1, farther from center).
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.onLodChunk(lodProtocol(9, 0, 1));
+
+    manager.update([0, 0]);
+    expect(countMeshes(manager)).toBe(1);
+
+    manager.update([0, 0]);
+    expect(countMeshes(manager)).toBe(2);
+  });
+
+  it("batches repeated arrivals into one rebuild per cooldown window", () => {
+    const { manager } = makeManager(
+      {},
+      { maxRegionRebuildsPerUpdate: 64, regionRebuildCooldown: 5 },
+    );
+
+    manager.update([0, 0]);
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.update([0, 0]);
+    expect(countMeshes(manager)).toBe(1);
+    const firstMesh = manager.group.children[0].children[0];
+
+    // A second arrival into the same region within the cooldown must not
+    // trigger an immediate re-merge...
+    manager.onLodChunk(lodProtocol(7, 0, 1));
+    manager.update([0, 0]);
+    expect(manager.group.children[0].children[0]).toBe(firstMesh);
+
+    // ...but once the cooldown elapses the region re-merges with both.
+    for (let i = 0; i < 5; i++) manager.update([0, 0]);
+    const rebuilt = manager.group.children[0].children[0] as Mesh;
+    expect(rebuilt).not.toBe(firstMesh);
+    expect(rebuilt.geometry.getAttribute("position").count).toBe(8);
+  });
+
+  it("defers full-chunk disposal until the LOD region actually re-merged", () => {
+    const fullActive = new Set(["9,0"]);
+    const { manager, log } = makeManager(
+      { isFullChunkActive: (cx, cz) => fullActive.has(`${cx},${cz}`) },
+      { maxRegionRebuildsPerUpdate: 1 },
+    );
+
+    manager.update([0, 0]);
+    // Nearer region (chunk 6,0) competes for the single-slot budget with the
+    // demote replacement for chunk (9,0) in the farther region.
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.onLodChunk(lodProtocol(9, 0, 1));
+
+    manager.update([0, 0]);
+    expect(log.disposedFull).toHaveLength(0);
+
+    manager.update([0, 0]);
+    expect(log.disposedFull).toEqual([[9, 0]]);
+  });
+
+  it("defers the full-chunk reveal until the LOD form left the scene", () => {
+    const { manager, log } = makeManager({}, { maxRegionRebuildsPerUpdate: 1 });
+
+    manager.update([0, 0]);
+    manager.onLodChunk(lodProtocol(9, 0, 1));
+    manager.update([0, 0]);
+    expect(manager.hasDisplayedForm(9, 0)).toBe(true);
+
+    // Retire the LOD form while a nearer region hogs the rebuild budget.
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.onFullChunkDisplayable(9, 0);
+
+    manager.update([0, 0]);
+    expect(log.revealedFull).toHaveLength(0);
+
+    manager.update([0, 0]);
+    expect(log.revealedFull).toEqual([[9, 0]]);
   });
 });

--- a/packages/core/src/core/world/chunk-lod.test.ts
+++ b/packages/core/src/core/world/chunk-lod.test.ts
@@ -1,0 +1,347 @@
+import { ChunkProtocol } from "@voxelize/protocol";
+import { Material, Mesh, MeshBasicMaterial } from "three";
+import { describe, expect, it } from "vitest";
+
+import { Coords2 } from "../../types";
+
+import {
+  LodChunkManager,
+  LodChunkManagerHost,
+  lodLevelForDistance,
+  lodRegionKey,
+  lodRegionSideInChunks,
+  resolveLodTarget,
+} from "./chunk-lod";
+
+describe("lodLevelForDistance", () => {
+  it("maps distance to geometric rings around the render radius", () => {
+    const R = 8;
+    expect(lodLevelForDistance(0, R, 3)).toBe(0);
+    expect(lodLevelForDistance(8, R, 3)).toBe(0);
+    expect(lodLevelForDistance(8.5, R, 3)).toBe(1);
+    expect(lodLevelForDistance(16, R, 3)).toBe(1);
+    expect(lodLevelForDistance(16.5, R, 3)).toBe(2);
+    expect(lodLevelForDistance(32, R, 3)).toBe(2);
+    expect(lodLevelForDistance(33, R, 3)).toBe(3);
+    expect(lodLevelForDistance(64, R, 3)).toBe(3);
+    expect(lodLevelForDistance(64.5, R, 3)).toBeNull();
+  });
+
+  it("caps at the configured max level", () => {
+    expect(lodLevelForDistance(100, 8, 1)).toBeNull();
+    expect(lodLevelForDistance(16, 8, 1)).toBe(1);
+  });
+});
+
+describe("resolveLodTarget hysteresis", () => {
+  const R = 8;
+  const MAX = 2;
+  const H = 1;
+
+  it("keeps the current level inside the widened ring band", () => {
+    // A chunk displayed at LOD 1 (ring 8..16) stays LOD 1 anywhere in
+    // (7, 17], so hovering exactly on a boundary never thrashes.
+    expect(resolveLodTarget(7.5, 1, R, MAX, H)).toBe(1);
+    expect(resolveLodTarget(16.9, 1, R, MAX, H)).toBe(1);
+    expect(resolveLodTarget(7.5, 0, R, MAX, H)).toBe(0);
+    expect(resolveLodTarget(16.9, 2, R, MAX, H)).toBe(2);
+  });
+
+  it("switches once the band is left", () => {
+    expect(resolveLodTarget(6.9, 1, R, MAX, H)).toBe(0);
+    expect(resolveLodTarget(17.1, 1, R, MAX, H)).toBe(2);
+    expect(resolveLodTarget(33.1, 2, R, MAX, H)).toBeNull();
+  });
+
+  it("is stable under oscillation across a boundary", () => {
+    // Walk back and forth across the 0/1 boundary at 8 chunks: the level
+    // computed from the previous level must never flip on sub-band moves.
+    let level: number | null = 0;
+    for (const distance of [7.8, 8.2, 7.9, 8.4, 7.7, 8.6]) {
+      const next = resolveLodTarget(distance, level, R, MAX, H);
+      expect(next).toBe(0);
+      level = next;
+    }
+  });
+
+  it("assigns fresh chunks their ring level directly", () => {
+    expect(resolveLodTarget(12, null, R, MAX, H)).toBe(1);
+    expect(resolveLodTarget(20, null, R, MAX, H)).toBe(2);
+    expect(resolveLodTarget(40, null, R, MAX, H)).toBeNull();
+  });
+});
+
+describe("lod regions", () => {
+  it("doubles region side with level for constant per-ring draw calls", () => {
+    expect(lodRegionSideInChunks(1)).toBe(4);
+    expect(lodRegionSideInChunks(2)).toBe(8);
+    expect(lodRegionSideInChunks(3)).toBe(16);
+  });
+
+  it("buckets chunk coords into level-scoped regions", () => {
+    expect(lodRegionKey(0, 0, 1)).toBe("1|0,0");
+    expect(lodRegionKey(3, 3, 1)).toBe("1|0,0");
+    expect(lodRegionKey(4, 0, 1)).toBe("1|1,0");
+    expect(lodRegionKey(-1, -1, 1)).toBe("1|-1,-1");
+    expect(lodRegionKey(4, 0, 2)).toBe("2|0,0");
+  });
+});
+
+type HostLog = {
+  requested: [number, number, number][][];
+  unloaded: Coords2[][];
+  disposedFull: Coords2[];
+  revealedFull: Coords2[];
+  refreshedFull: Coords2[];
+};
+
+function makeHost(overrides: Partial<LodChunkManagerHost> = {}): {
+  host: LodChunkManagerHost;
+  log: HostLog;
+} {
+  const log: HostLog = {
+    requested: [],
+    unloaded: [],
+    disposedFull: [],
+    revealedFull: [],
+    refreshedFull: [],
+  };
+
+  const material = new MeshBasicMaterial() as Material;
+
+  const host: LodChunkManagerHost = {
+    chunkSize: 16,
+    renderRadius: () => 4,
+    resolveMaterial: () => ({ key: "default", material }),
+    configureTransparentMesh: () => undefined,
+    requestLodChunks: (requests) => log.requested.push(requests),
+    unloadChunks: (coords) => log.unloaded.push(coords),
+    isWithinWorld: () => true,
+    isFullChunkActive: () => false,
+    disposeFullChunk: (cx, cz) => log.disposedFull.push([cx, cz]),
+    setFullChunkVisible: (cx, cz, isVisible) => {
+      if (isVisible) log.revealedFull.push([cx, cz]);
+    },
+    refreshFullChunk: (cx, cz) => log.refreshedFull.push([cx, cz]),
+    ...overrides,
+  };
+
+  return { host, log };
+}
+
+function makeManager(
+  overrides: Partial<LodChunkManagerHost> = {},
+  maxLodLevel = 2,
+) {
+  const { host, log } = makeHost(overrides);
+  const manager = new LodChunkManager(host, {
+    maxLodLevel,
+    hysteresis: 1,
+    maxRequestsPerUpdate: 512,
+    rerequestInterval: 300,
+    maxLodRadius: 96,
+  });
+  return { manager, log };
+}
+
+function lodProtocol(
+  cx: number,
+  cz: number,
+  lod: number,
+  quads = 1,
+): ChunkProtocol {
+  const positions = new Float32Array(quads * 12);
+  const indices = new Uint32Array(quads * 6);
+  for (let quad = 0; quad < quads; quad++) {
+    const base = quad * 4;
+    indices.set(
+      [base, base + 1, base + 2, base + 2, base + 1, base + 3],
+      quad * 6,
+    );
+  }
+
+  return {
+    id: `${cx},${cz}`,
+    x: cx,
+    z: cz,
+    voxels: new Uint32Array(),
+    lights: new Uint32Array(),
+    meshes: [
+      {
+        level: 0,
+        lod,
+        geometries: [
+          {
+            voxel: 1,
+            positions,
+            indices,
+            uvs: new Float32Array(quads * 8),
+            lights: new Uint32Array(quads * 4),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("LodChunkManager", () => {
+  it("requests ring chunks nearest-first and skips the full-detail disc", () => {
+    const { manager, log } = makeManager();
+
+    manager.update([0, 0]);
+
+    expect(log.requested.length).toBeGreaterThan(0);
+    const requests = log.requested.flat();
+
+    for (const [cx, cz, level] of requests) {
+      const distance = Math.sqrt(cx * cx + cz * cz);
+      expect(distance).toBeGreaterThan(4);
+      expect(level).toBe(lodLevelForDistance(distance, 4, 2));
+    }
+
+    // Nearest-first ordering across the whole candidate list.
+    const distances = requests.map(([cx, cz]) => Math.sqrt(cx * cx + cz * cz));
+    const sorted = [...distances].sort((a, b) => a - b);
+    expect(distances).toEqual(sorted);
+  });
+
+  it("displays arrived meshes in level-scoped regions", () => {
+    const { manager } = makeManager();
+
+    manager.update([0, 0]);
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.onLodChunk(lodProtocol(7, 0, 1));
+    manager.onLodChunk(lodProtocol(10, 0, 2));
+    manager.update([0, 0]);
+
+    expect(manager.displayedCount).toBe(3);
+
+    const meshes: Mesh[] = [];
+    manager.group.traverse((object) => {
+      if ((object as Mesh).isMesh) meshes.push(object as Mesh);
+    });
+
+    // 6,0 and 7,0 share a level-1 region; 10,0 lives in a level-2 region.
+    expect(meshes).toHaveLength(2);
+
+    const merged = meshes.find((mesh) => mesh.userData.lodLevel === 1) as Mesh;
+    const positionCount = merged.geometry.getAttribute("position").array.length;
+    expect(positionCount).toBe(2 * 12);
+  });
+
+  it("offsets merged chunk geometry by chunk world position", () => {
+    const { manager } = makeManager();
+
+    const protocol = lodProtocol(6, 0, 1);
+    protocol.meshes[0].geometries[0].positions.set([1, 2, 3], 0);
+
+    manager.update([0, 0]);
+    manager.onLodChunk(protocol);
+    manager.update([0, 0]);
+
+    const meshes: Mesh[] = [];
+    manager.group.traverse((object) => {
+      if ((object as Mesh).isMesh) meshes.push(object as Mesh);
+    });
+    expect(meshes).toHaveLength(1);
+
+    const positions = meshes[0].geometry.getAttribute("position")
+      .array as Float32Array;
+    expect(positions[0]).toBe(1 + 6 * 16);
+    expect(positions[1]).toBe(2);
+    expect(positions[2]).toBe(3);
+  });
+
+  it("swaps LOD levels atomically when a replacement level arrives", () => {
+    const { manager } = makeManager();
+
+    manager.update([0, 0]);
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.update([0, 0]);
+    manager.onLodChunk(lodProtocol(6, 0, 2));
+    manager.update([0, 0]);
+
+    expect(manager.displayedCount).toBe(1);
+
+    const levels: number[] = [];
+    manager.group.traverse((object) => {
+      if ((object as Mesh).isMesh) {
+        levels.push((object as Mesh).userData.lodLevel);
+      }
+    });
+    expect(levels).toEqual([2]);
+  });
+
+  it("disposes the full form only after its LOD replacement displays", () => {
+    const fullActive = new Set(["6,0"]);
+    const { manager, log } = makeManager({
+      isFullChunkActive: (cx, cz) => fullActive.has(`${cx},${cz}`),
+    });
+
+    manager.update([0, 0]);
+    expect(log.disposedFull).toHaveLength(0);
+
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.update([0, 0]);
+
+    expect(log.disposedFull).toEqual([[6, 0]]);
+    expect(manager.hasDisplayedForm(6, 0)).toBe(true);
+  });
+
+  it("retires the LOD form and reveals the full chunk when displayable", () => {
+    const { manager, log } = makeManager();
+
+    manager.update([0, 0]);
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.update([0, 0]);
+    expect(manager.hasDisplayedForm(6, 0)).toBe(true);
+
+    manager.onFullChunkDisplayable(6, 0);
+    manager.update([0, 0]);
+
+    expect(manager.hasDisplayedForm(6, 0)).toBe(false);
+    expect(log.revealedFull).toEqual([[6, 0]]);
+
+    let meshCount = 0;
+    manager.group.traverse((object) => {
+      if ((object as Mesh).isMesh) meshCount++;
+    });
+    expect(meshCount).toBe(0);
+  });
+
+  it("discards stale LOD arrivals for chunks back inside the full ring", () => {
+    const { manager, log } = makeManager({
+      isFullChunkActive: (cx, cz) => cx === 2 && cz === 0,
+    });
+
+    manager.update([0, 0]);
+    manager.onLodChunk(lodProtocol(2, 0, 1));
+    manager.update([0, 0]);
+
+    expect(manager.hasDisplayedForm(2, 0)).toBe(false);
+    expect(log.disposedFull).toHaveLength(0);
+    expect(log.refreshedFull).toEqual([[2, 0]]);
+  });
+
+  it("unloads chunks beyond the LOD horizon", () => {
+    const { manager, log } = makeManager();
+
+    manager.update([0, 0]);
+    manager.onLodChunk(lodProtocol(6, 0, 1));
+    manager.update([0, 0]);
+    expect(manager.displayedCount).toBe(1);
+
+    // Teleport far away: the chunk leaves the scan window entirely.
+    manager.update([1000, 1000]);
+
+    expect(manager.displayedCount).toBe(0);
+    expect(log.unloaded.flat()).toContainEqual([6, 0]);
+  });
+
+  it("keeps chunks in the full-detail disc out of its ownership", () => {
+    const { manager } = makeManager();
+    manager.update([0, 0]);
+    expect(manager.owns(0, 0)).toBe(false);
+    expect(manager.owns(2, 2)).toBe(false);
+  });
+});

--- a/packages/core/src/core/world/chunk-lod.test.ts
+++ b/packages/core/src/core/world/chunk-lod.test.ts
@@ -229,6 +229,30 @@ describe("LodChunkManager", () => {
     expect(positionCount).toBe(2 * 12);
   });
 
+  it("stamps the region LOD level into the merged light attribute", () => {
+    const { manager } = makeManager();
+
+    const protocol = lodProtocol(10, 0, 2);
+    protocol.meshes[0].geometries[0].lights.set([0xf0f0, 0x0f0f, 7, 0], 0);
+
+    manager.update([0, 0]);
+    manager.onLodChunk(protocol);
+    manager.update([0, 0]);
+
+    const meshes: Mesh[] = [];
+    manager.group.traverse((object) => {
+      if ((object as Mesh).isMesh) meshes.push(object as Mesh);
+    });
+    expect(meshes).toHaveLength(1);
+
+    const lights = meshes[0].geometry.getAttribute("light").array as Int32Array;
+    const levelBits = 2 << 21;
+    expect(lights[0]).toBe(0xf0f0 | levelBits);
+    expect(lights[1]).toBe(0x0f0f | levelBits);
+    expect(lights[2]).toBe(7 | levelBits);
+    expect(lights[3]).toBe(levelBits);
+  });
+
   it("offsets merged chunk geometry by chunk world position", () => {
     const { manager } = makeManager();
 

--- a/packages/core/src/core/world/chunk-lod.ts
+++ b/packages/core/src/core/world/chunk-lod.ts
@@ -402,32 +402,44 @@ export class LodChunkManager {
     this.candidates = [];
   }
 
+  /**
+   * Recompute what every chunk in the LOD window should be doing. Two passes
+   * keep it cheap enough to run on every chunk-border crossing: tracked
+   * chunks (a few thousand at most) get the full level/retry/removal logic,
+   * then the discovery sweep over the window runs allocation-free per cell —
+   * pure arithmetic plus a numeric-key set — and only produces candidates
+   * for untracked ring chunks.
+   */
   private scan(center: Coords2): void {
     const renderRadius = this.host.renderRadius();
-    const maxLodLevel = this.options.maxLodLevel;
-    const hysteresis = this.options.hysteresis;
+    const { maxLodLevel, hysteresis, rerequestInterval } = this.options;
     const scanRadius = Math.ceil(this.visualRadius + hysteresis);
     const [centerX, centerZ] = center;
 
     const requests: { cx: number; cz: number; level: number; d: number }[] = [];
     const toRemove: LodChunkState[] = [];
-    const visited = new Set<string>();
 
-    const consider = (cx: number, cz: number, distance: number) => {
-      if (!this.host.isWithinWorld(cx, cz)) return;
+    const stride = scanRadius * 2 + 1;
+    const windowKey = (cx: number, cz: number) =>
+      (cx - centerX + scanRadius) * stride + (cz - centerZ + scanRadius);
+    const tracked = new Set<number>();
 
-      const name = ChunkUtils.getChunkName([cx, cz]);
-      visited.add(name);
-      const state = this.states.get(name);
+    for (const state of this.states.values()) {
+      const [cx, cz] = state.coords;
+      const dx = cx - centerX;
+      const dz = cz - centerZ;
+      const distance = Math.sqrt(dx * dx + dz * dz);
 
-      const isFullActive = this.host.isFullChunkActive(cx, cz);
+      if (distance > scanRadius) {
+        toRemove.push(state);
+        continue;
+      }
+
+      tracked.add(windowKey(cx, cz));
+
       const currentLevel =
-        state?.displayedLevel != null
-          ? state.displayedLevel
-          : isFullActive
-            ? 0
-            : null;
-
+        state.displayedLevel ??
+        (this.host.isFullChunkActive(cx, cz) ? 0 : null);
       const target = resolveLodTarget(
         distance,
         currentLevel,
@@ -437,47 +449,64 @@ export class LodChunkManager {
       );
 
       if (target === null) {
-        if (state) toRemove.push(state);
-        return;
+        toRemove.push(state);
+        continue;
       }
 
       if (target === 0) {
         // The full-detail pipeline owns requesting; the LOD form (if any)
         // stays displayed until the full chunk reports displayable.
-        if (state?.requestedLevel != null) state.requestedLevel = null;
-        return;
+        if (state.requestedLevel != null) state.requestedLevel = null;
+        continue;
       }
 
-      if (state?.displayedLevel === target) {
+      if (state.displayedLevel === target) {
         if (state.requestedLevel != null && state.requestedLevel !== target) {
           state.requestedLevel = null;
         }
-        return;
+        continue;
       }
 
-      if (state?.requestedLevel === target) {
-        const age = this.updateCount - state.requestedAt;
-        if (age <= this.options.rerequestInterval) return;
+      if (
+        state.requestedLevel === target &&
+        this.updateCount - state.requestedAt <= rerequestInterval
+      ) {
+        continue;
       }
 
       requests.push({ cx, cz, level: target, d: distance });
-    };
+    }
+
+    // Full-detail chunks only exist near the render radius (or transiently
+    // just past it mid-demote); beyond this bound the loaded-chunk lookup is
+    // pointless, and a stray full chunk further out still demotes correctly
+    // once its LOD mesh arrives.
+    const fullLookupBound = renderRadius + hysteresis + 2;
 
     for (let ox = -scanRadius; ox <= scanRadius; ox++) {
       for (let oz = -scanRadius; oz <= scanRadius; oz++) {
         const distance = Math.sqrt(ox * ox + oz * oz);
         if (distance > scanRadius) continue;
-        consider(centerX + ox, centerZ + oz, distance);
-      }
-    }
 
-    // States drifting outside the scan window (fast travel) still retire.
-    for (const state of this.states.values()) {
-      if (visited.has(state.name)) continue;
-      const dx = state.coords[0] - centerX;
-      const dz = state.coords[1] - centerZ;
-      if (Math.sqrt(dx * dx + dz * dz) > scanRadius) {
-        toRemove.push(state);
+        const cx = centerX + ox;
+        const cz = centerZ + oz;
+        if (tracked.has(windowKey(cx, cz))) continue;
+
+        const currentLevel =
+          distance <= fullLookupBound && this.host.isFullChunkActive(cx, cz)
+            ? 0
+            : null;
+        const target = resolveLodTarget(
+          distance,
+          currentLevel,
+          renderRadius,
+          maxLodLevel,
+          hysteresis,
+        );
+        if (target === null || target === 0) continue;
+        if (!this.host.isWithinWorld(cx, cz)) continue;
+
+        requests.push({ cx, cz, level: target, d: distance });
       }
     }
 

--- a/packages/core/src/core/world/chunk-lod.ts
+++ b/packages/core/src/core/world/chunk-lod.ts
@@ -1,5 +1,13 @@
 import { ChunkProtocol, GeometryProtocol } from "@voxelize/protocol";
-import { BufferAttribute, BufferGeometry, Group, Material, Mesh } from "three";
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Group,
+  Material,
+  Mesh,
+  Sphere,
+  Vector3,
+} from "three";
 
 import { Coords2 } from "../../types";
 import { ChunkUtils } from "../../utils";
@@ -83,7 +91,7 @@ export function resolveLodTarget(
  * how far it is.
  */
 export function lodRegionSideInChunks(level: number): number {
-  return 1 << (level + 1);
+  return 1 << (level + 2);
 }
 
 export function lodRegionKey(cx: number, cz: number, level: number): string {
@@ -131,19 +139,47 @@ export type LodChunkManagerOptions = {
   rerequestInterval: number;
   /** Hard clamp on the LOD horizon, in chunks. */
   maxLodRadius: number;
+  /**
+   * How many region meshes may be re-merged (and re-uploaded) per update.
+   * This is the throttle that keeps ring transitions hitch-free: swaps whose
+   * region has not been rebuilt yet simply stay on their previous form.
+   */
+  maxRegionRebuildsPerUpdate: number;
+  /**
+   * Minimum updates between two rebuilds of the same region, so a region
+   * receiving a stream of chunk arrivals batches them instead of re-merging
+   * per arrival.
+   */
+  regionRebuildCooldown: number;
+};
+
+/**
+ * A chunk's LOD geometry, converted once at arrival into merge-ready typed
+ * arrays — material resolved, flat normals computed — so region rebuilds are
+ * pure buffer copies.
+ */
+type PreparedLodGeometry = {
+  materialKey: string;
+  material: Material;
+  voxel: number;
+  positions: Float32Array;
+  uvs: Float32Array;
+  lights: ArrayLike<number>;
+  indices: ArrayLike<number>;
+  normals: Float32Array;
 };
 
 type LodGeometryBucket = {
   material: Material;
   voxel: number;
-  geometries: { chunk: LodChunkState; geometry: GeometryProtocol }[];
+  geometries: { chunk: LodChunkState; geometry: PreparedLodGeometry }[];
 };
 
 type LodChunkState = {
   name: string;
   coords: Coords2;
   displayedLevel: number | null;
-  geometries: GeometryProtocol[] | null;
+  geometries: PreparedLodGeometry[] | null;
   requestedLevel: number | null;
   requestedAt: number;
 };
@@ -151,13 +187,17 @@ type LodChunkState = {
 type LodRegion = {
   key: string;
   level: number;
+  /** Region center in chunk coordinates, for rebuild prioritization. */
+  center: Coords2;
   members: Set<LodChunkState>;
   group: Group;
   meshes: Mesh[];
   isDirty: boolean;
+  /** Update count of the last rebuild, for the rebuild cooldown. */
+  lastRebuildAt: number;
 };
 
-const SCAN_INTERVAL_UPDATES = 30;
+const SCAN_INTERVAL_UPDATES = 90;
 
 function computeFlatNormalsInto(
   normals: Float32Array,
@@ -214,14 +254,21 @@ export class LodChunkManager {
   private lastCenter: Coords2 | null = null;
 
   private candidates: [number, number, number][] = [];
-  private pendingFullDisposals: Coords2[] = [];
-  private pendingFullReveals: Coords2[] = [];
+
+  // Swap commits deferred until the region holding the chunk's new (or old)
+  // form has actually re-merged, so a form is never torn down before its
+  // replacement geometry is on screen — even though rebuilds are budgeted
+  // across frames.
+  private pendingFullDisposals: { name: string; coords: Coords2 }[] = [];
+  private pendingFullReveals: { coords: Coords2; regionKey: string }[] = [];
 
   constructor(
     private host: LodChunkManagerHost,
     private options: LodChunkManagerOptions,
   ) {
     this.group.name = "lod-chunks";
+    this.group.matrixAutoUpdate = false;
+    this.group.updateMatrix();
   }
 
   get maxLodLevel(): number {
@@ -318,15 +365,70 @@ export class LodChunkManager {
       this.removeFromRegion(state, state.displayedLevel);
     }
 
-    state.geometries = mesh.geometries ?? [];
+    state.geometries = this.prepareGeometries(mesh.geometries ?? []);
     state.displayedLevel = level;
     this.addToRegion(state, level);
 
     // Reaching here with an active full form means this arrival is the
-    // demote replacement: the full chunk is disposed after regions rebuild.
+    // demote replacement: the full chunk is disposed once the region that
+    // now carries the LOD geometry has rebuilt.
     if (this.host.isFullChunkActive(x, z)) {
-      this.pendingFullDisposals.push([x, z]);
+      if (!this.pendingFullDisposals.some((entry) => entry.name === name)) {
+        this.pendingFullDisposals.push({ name, coords: [x, z] });
+      }
     }
+  }
+
+  /**
+   * Convert wire geometries into merge-ready form once, at arrival: resolve
+   * the material (and its bucket identity), and compute flat normals —
+   * normals depend only on the chunk's own geometry, never on region
+   * membership. Region rebuilds then reduce to buffer copies.
+   */
+  private prepareGeometries(
+    geometries: GeometryProtocol[],
+  ): PreparedLodGeometry[] {
+    const prepared: PreparedLodGeometry[] = [];
+
+    for (const geometry of geometries) {
+      if (!geometry.positions?.length || !geometry.indices?.length) {
+        continue;
+      }
+      // Isolated per-position faces cannot resolve a shared material at LOD
+      // scale; the downsampler avoids such representatives, so simply skip
+      // the rare leftover face.
+      if (geometry.at && geometry.at.length) continue;
+
+      const resolved = this.host.resolveMaterial(
+        geometry.voxel,
+        geometry.faceName ?? undefined,
+      );
+      if (!resolved) continue;
+
+      const positions =
+        geometry.positions instanceof Float32Array
+          ? geometry.positions
+          : new Float32Array(geometry.positions);
+      const indices = new Uint32Array(geometry.indices);
+      const normals = new Float32Array(positions.length);
+      computeFlatNormalsInto(normals, positions, indices);
+
+      prepared.push({
+        materialKey: resolved.key,
+        material: resolved.material,
+        voxel: geometry.voxel,
+        positions,
+        uvs:
+          geometry.uvs instanceof Float32Array
+            ? geometry.uvs
+            : new Float32Array(geometry.uvs),
+        lights: geometry.lights,
+        indices,
+        normals,
+      });
+    }
+
+    return prepared;
   }
 
   /**
@@ -338,11 +440,12 @@ export class LodChunkManager {
     const state = this.states.get(ChunkUtils.getChunkName([cx, cz]));
     if (!state || state.displayedLevel === null) return;
 
+    const regionKey = lodRegionKey(cx, cz, state.displayedLevel);
     this.removeFromRegion(state, state.displayedLevel);
     state.displayedLevel = null;
     state.geometries = null;
     state.requestedLevel = null;
-    this.pendingFullReveals.push([cx, cz]);
+    this.pendingFullReveals.push({ coords: [cx, cz], regionKey });
   }
 
   /**
@@ -382,14 +485,16 @@ export class LodChunkManager {
       centerChanged ||
       this.updateCount - this.lastScanUpdate >= SCAN_INTERVAL_UPDATES
     ) {
-      this.scan(center);
+      // Discovery of never-requested cells is only needed when the window
+      // itself moved; the periodic safety-net scan just maintains tracked
+      // chunks (retries, removals) at a fraction of the cost.
+      this.scan(center, centerChanged);
       this.lastScanUpdate = this.updateCount;
       this.lastCenter = [center[0], center[1]];
     }
 
     this.flushRequests();
-    this.rebuildDirtyRegions();
-    this.commitSwaps();
+    this.rebuildBudgetedRegions(center);
   }
 
   dispose(): void {
@@ -400,6 +505,8 @@ export class LodChunkManager {
     this.regions.clear();
     this.states.clear();
     this.candidates = [];
+    this.pendingFullDisposals = [];
+    this.pendingFullReveals = [];
   }
 
   /**
@@ -410,7 +517,7 @@ export class LodChunkManager {
    * pure arithmetic plus a numeric-key set — and only produces candidates
    * for untracked ring chunks.
    */
-  private scan(center: Coords2): void {
+  private scan(center: Coords2, isDiscovering: boolean): void {
     const renderRadius = this.host.renderRadius();
     const { maxLodLevel, hysteresis, rerequestInterval } = this.options;
     const scanRadius = Math.ceil(this.visualRadius + hysteresis);
@@ -422,7 +529,7 @@ export class LodChunkManager {
     const stride = scanRadius * 2 + 1;
     const windowKey = (cx: number, cz: number) =>
       (cx - centerX + scanRadius) * stride + (cz - centerZ + scanRadius);
-    const tracked = new Set<number>();
+    const tracked = isDiscovering ? new Set<number>() : null;
 
     for (const state of this.states.values()) {
       const [cx, cz] = state.coords;
@@ -435,7 +542,7 @@ export class LodChunkManager {
         continue;
       }
 
-      tracked.add(windowKey(cx, cz));
+      tracked?.add(windowKey(cx, cz));
 
       const currentLevel =
         state.displayedLevel ??
@@ -477,41 +584,54 @@ export class LodChunkManager {
       requests.push({ cx, cz, level: target, d: distance });
     }
 
-    // Full-detail chunks only exist near the render radius (or transiently
-    // just past it mid-demote); beyond this bound the loaded-chunk lookup is
-    // pointless, and a stray full chunk further out still demotes correctly
-    // once its LOD mesh arrives.
-    const fullLookupBound = renderRadius + hysteresis + 2;
+    if (tracked) {
+      // Full-detail chunks only exist near the render radius (or transiently
+      // just past it mid-demote); beyond this bound the loaded-chunk lookup
+      // is pointless, and a stray full chunk further out still demotes
+      // correctly once its LOD mesh arrives.
+      const fullLookupBound = renderRadius + hysteresis + 2;
 
-    for (let ox = -scanRadius; ox <= scanRadius; ox++) {
-      for (let oz = -scanRadius; oz <= scanRadius; oz++) {
-        const distance = Math.sqrt(ox * ox + oz * oz);
-        if (distance > scanRadius) continue;
+      for (let ox = -scanRadius; ox <= scanRadius; ox++) {
+        for (let oz = -scanRadius; oz <= scanRadius; oz++) {
+          const distance = Math.sqrt(ox * ox + oz * oz);
+          if (distance > scanRadius) continue;
 
-        const cx = centerX + ox;
-        const cz = centerZ + oz;
-        if (tracked.has(windowKey(cx, cz))) continue;
+          const cx = centerX + ox;
+          const cz = centerZ + oz;
+          if (tracked.has(windowKey(cx, cz))) continue;
 
-        const currentLevel =
-          distance <= fullLookupBound && this.host.isFullChunkActive(cx, cz)
-            ? 0
-            : null;
-        const target = resolveLodTarget(
-          distance,
-          currentLevel,
-          renderRadius,
-          maxLodLevel,
-          hysteresis,
-        );
-        if (target === null || target === 0) continue;
-        if (!this.host.isWithinWorld(cx, cz)) continue;
+          const currentLevel =
+            distance <= fullLookupBound && this.host.isFullChunkActive(cx, cz)
+              ? 0
+              : null;
+          const target = resolveLodTarget(
+            distance,
+            currentLevel,
+            renderRadius,
+            maxLodLevel,
+            hysteresis,
+          );
+          if (target === null || target === 0) continue;
+          if (!this.host.isWithinWorld(cx, cz)) continue;
 
-        requests.push({ cx, cz, level: target, d: distance });
+          requests.push({ cx, cz, level: target, d: distance });
+        }
       }
     }
 
     requests.sort((a, b) => a.d - b.d);
-    this.candidates = requests.map(({ cx, cz, level }) => [cx, cz, level]);
+    if (isDiscovering) {
+      this.candidates = requests.map(({ cx, cz, level }) => [cx, cz, level]);
+    } else {
+      // Maintenance scans only produce tracked-chunk work (retries, level
+      // changes) — disjoint from any still-unflushed discovery candidates,
+      // which must survive until their turn in the request budget.
+      this.candidates.push(
+        ...requests.map(
+          ({ cx, cz, level }) => [cx, cz, level] as [number, number, number],
+        ),
+      );
+    }
 
     if (toRemove.length) {
       const unloaded: Coords2[] = [];
@@ -560,15 +680,23 @@ export class LodChunkManager {
     const key = lodRegionKey(state.coords[0], state.coords[1], level);
     let region = this.regions.get(key);
     if (!region) {
+      const side = lodRegionSideInChunks(level);
       region = {
         key,
         level,
+        center: [
+          (Math.floor(state.coords[0] / side) + 0.5) * side,
+          (Math.floor(state.coords[1] / side) + 0.5) * side,
+        ],
         members: new Set(),
         group: new Group(),
         meshes: [],
         isDirty: false,
+        lastRebuildAt: -Infinity,
       };
       region.group.name = `lod-region-${key}`;
+      region.group.matrixAutoUpdate = false;
+      region.group.updateMatrix();
       this.group.add(region.group);
       this.regions.set(key, region);
     }
@@ -584,27 +712,93 @@ export class LodChunkManager {
     region.isDirty = true;
   }
 
-  private rebuildDirtyRegions(): void {
+  /**
+   * Re-merge at most `maxRegionRebuildsPerUpdate` dirty regions per update,
+   * nearest first, each no more often than the cooldown allows. Everything
+   * else stays exactly as it was — a dirty region keeps showing its previous
+   * merge, and the swap commits waiting on it stay on their previous form —
+   * so ring transitions cost a bounded slice of every frame instead of one
+   * long stall at the boundary.
+   */
+  private rebuildBudgetedRegions(center: Coords2): void {
+    let candidates: { region: LodRegion; distanceSquared: number }[] | null =
+      null;
+
     for (const region of this.regions.values()) {
       if (!region.isDirty) continue;
+      if (
+        this.updateCount - region.lastRebuildAt <
+        this.options.regionRebuildCooldown
+      ) {
+        continue;
+      }
+
+      const dx = region.center[0] - center[0];
+      const dz = region.center[1] - center[1];
+      (candidates ??= []).push({
+        region,
+        distanceSquared: dx * dx + dz * dz,
+      });
+    }
+
+    if (!candidates) return;
+
+    candidates.sort((a, b) => a.distanceSquared - b.distanceSquared);
+
+    const budget = Math.min(
+      this.options.maxRegionRebuildsPerUpdate,
+      candidates.length,
+    );
+    for (let i = 0; i < budget; i++) {
+      const region = candidates[i].region;
       region.isDirty = false;
+      region.lastRebuildAt = this.updateCount;
       this.rebuildRegion(region);
+      this.commitSwapsForRegion(region.key);
     }
   }
 
-  private commitSwaps(): void {
+  /**
+   * Commit the form swaps that were waiting for this region's geometry to
+   * hit the scene: full-chunk disposals whose LOD replacement lives (and is
+   * now merged) in this region, and full-chunk reveals whose LOD stand-in
+   * was removed from it.
+   */
+  private commitSwapsForRegion(regionKey: string): void {
     if (this.pendingFullDisposals.length) {
-      for (const [cx, cz] of this.pendingFullDisposals) {
-        this.host.disposeFullChunk(cx, cz);
+      const remaining: { name: string; coords: Coords2 }[] = [];
+      for (const entry of this.pendingFullDisposals) {
+        const state = this.states.get(entry.name);
+        // The LOD form may have retired (promote finished first) or changed
+        // level meanwhile; keep waiting for whichever region carries the
+        // current form, and drop the entry when there is nothing to wait on.
+        if (!state || state.displayedLevel === null) {
+          continue;
+        }
+        const currentKey = lodRegionKey(
+          state.coords[0],
+          state.coords[1],
+          state.displayedLevel,
+        );
+        if (currentKey === regionKey) {
+          this.host.disposeFullChunk(entry.coords[0], entry.coords[1]);
+        } else {
+          remaining.push(entry);
+        }
       }
-      this.pendingFullDisposals = [];
+      this.pendingFullDisposals = remaining;
     }
 
     if (this.pendingFullReveals.length) {
-      for (const [cx, cz] of this.pendingFullReveals) {
-        this.host.setFullChunkVisible(cx, cz, true);
+      const remaining: { coords: Coords2; regionKey: string }[] = [];
+      for (const entry of this.pendingFullReveals) {
+        if (entry.regionKey === regionKey) {
+          this.host.setFullChunkVisible(entry.coords[0], entry.coords[1], true);
+        } else {
+          remaining.push(entry);
+        }
       }
-      this.pendingFullReveals = [];
+      this.pendingFullReveals = remaining;
     }
   }
 
@@ -616,6 +810,13 @@ export class LodChunkManager {
     region.meshes = [];
   }
 
+  /**
+   * Re-merge one region's prepared chunk geometries into one mesh per
+   * material. All expensive per-geometry work (material resolution, normal
+   * computation) happened at arrival; this is buffer concatenation with a
+   * position offset, plus the bounding sphere derived from bounds tracked
+   * during the copy.
+   */
   private rebuildRegion(region: LodRegion): void {
     this.disposeRegionMeshes(region);
 
@@ -630,28 +831,14 @@ export class LodChunkManager {
     for (const state of region.members) {
       if (!state.geometries) continue;
       for (const geometry of state.geometries) {
-        if (!geometry.positions?.length || !geometry.indices?.length) {
-          continue;
-        }
-        // Isolated per-position faces cannot resolve a shared material at
-        // LOD scale; the downsampler avoids such representatives, so simply
-        // skip the rare leftover face.
-        if (geometry.at && geometry.at.length) continue;
-
-        const resolved = this.host.resolveMaterial(
-          geometry.voxel,
-          geometry.faceName ?? undefined,
-        );
-        if (!resolved) continue;
-
-        let bucket = buckets.get(resolved.key);
+        let bucket = buckets.get(geometry.materialKey);
         if (!bucket) {
           bucket = {
-            material: resolved.material,
+            material: geometry.material,
             voxel: geometry.voxel,
             geometries: [],
           };
-          buckets.set(resolved.key, bucket);
+          buckets.set(geometry.materialKey, bucket);
         }
         bucket.geometries.push({ chunk: state, geometry });
       }
@@ -675,10 +862,17 @@ export class LodChunkManager {
       const positions = new Float32Array(vertexCount * 3);
       const uvs = new Float32Array(vertexCount * 2);
       const lights = new Int32Array(vertexCount);
+      const normals = new Float32Array(vertexCount * 3);
       const indices = new Uint32Array(indexCount);
 
       let vertexBase = 0;
       let indexBase = 0;
+      let minX = Infinity;
+      let minY = Infinity;
+      let minZ = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      let maxZ = -Infinity;
 
       for (const { chunk, geometry } of bucket.geometries) {
         const offsetX = chunk.coords[0] * chunkSize;
@@ -686,12 +880,21 @@ export class LodChunkManager {
         const count = geometry.positions.length / 3;
 
         for (let i = 0; i < count; i++) {
-          positions[(vertexBase + i) * 3] = geometry.positions[i * 3] + offsetX;
-          positions[(vertexBase + i) * 3 + 1] = geometry.positions[i * 3 + 1];
-          positions[(vertexBase + i) * 3 + 2] =
-            geometry.positions[i * 3 + 2] + offsetZ;
+          const x = geometry.positions[i * 3] + offsetX;
+          const y = geometry.positions[i * 3 + 1];
+          const z = geometry.positions[i * 3 + 2] + offsetZ;
+          positions[(vertexBase + i) * 3] = x;
+          positions[(vertexBase + i) * 3 + 1] = y;
+          positions[(vertexBase + i) * 3 + 2] = z;
+          if (x < minX) minX = x;
+          if (y < minY) minY = y;
+          if (z < minZ) minZ = z;
+          if (x > maxX) maxX = x;
+          if (y > maxY) maxY = y;
+          if (z > maxZ) maxZ = z;
         }
         uvs.set(geometry.uvs, vertexBase * 2);
+        normals.set(geometry.normals, vertexBase * 3);
         for (let i = 0; i < count; i++) {
           lights[vertexBase + i] = geometry.lights[i] | lodLevelBits;
         }
@@ -703,16 +906,22 @@ export class LodChunkManager {
         indexBase += geometry.indices.length;
       }
 
-      const normals = new Float32Array(vertexCount * 3);
-      computeFlatNormalsInto(normals, positions, indices);
-
       const merged = new BufferGeometry();
       merged.setAttribute("position", new BufferAttribute(positions, 3));
       merged.setAttribute("uv", new BufferAttribute(uvs, 2));
       merged.setAttribute("light", new BufferAttribute(lights, 1));
       merged.setAttribute("normal", new BufferAttribute(normals, 3));
       merged.setIndex(new BufferAttribute(indices, 1));
-      merged.computeBoundingSphere();
+
+      const centerX = (minX + maxX) / 2;
+      const centerY = (minY + maxY) / 2;
+      const centerZ = (minZ + maxZ) / 2;
+      merged.boundingSphere = new Sphere(
+        new Vector3(centerX, centerY, centerZ),
+        Math.sqrt(
+          (maxX - centerX) ** 2 + (maxY - centerY) ** 2 + (maxZ - centerZ) ** 2,
+        ),
+      );
 
       const mesh = new Mesh(merged, bucket.material);
       mesh.matrixAutoUpdate = false;

--- a/packages/core/src/core/world/chunk-lod.ts
+++ b/packages/core/src/core/world/chunk-lod.ts
@@ -1,0 +1,700 @@
+import { ChunkProtocol, GeometryProtocol } from "@voxelize/protocol";
+import { BufferAttribute, BufferGeometry, Group, Material, Mesh } from "three";
+
+import { Coords2 } from "../../types";
+import { ChunkUtils } from "../../utils";
+
+/**
+ * Level-of-detail rendering of distant chunks.
+ *
+ * Worlds that enable `chunk_lod` server-side serve distant chunks as compact,
+ * reduced-detail whole-column meshes (see `crates/mesher/src/lod.rs` for the
+ * meshing and seam strategy). This module owns the client half:
+ *
+ * - mapping chunk distance to a LOD level in geometric rings — full detail up
+ *   to the render radius `R`, level `L` for distances in
+ *   `(R * 2^(L-1), R * 2^L]` — with a hysteresis band so chunks never thrash
+ *   between levels at a ring boundary,
+ * - requesting, tracking, and retiring LOD chunk meshes as the viewer moves,
+ *   swapping forms only when the replacement is ready (no popping holes, and
+ *   never two forms visible in the same frame),
+ * - batching LOD chunk geometry into per-region merged meshes so thousands of
+ *   distant chunks cost a handful of draw calls.
+ */
+
+/**
+ * The LOD level a chunk at `distance` (in chunks) should display, ignoring
+ * hysteresis: `0` for full detail, `1..maxLodLevel` for the LOD rings, and
+ * `null` beyond the outermost ring.
+ */
+export function lodLevelForDistance(
+  distance: number,
+  renderRadius: number,
+  maxLodLevel: number,
+): number | null {
+  if (distance <= renderRadius) {
+    return 0;
+  }
+
+  for (let level = 1; level <= maxLodLevel; level++) {
+    if (distance <= renderRadius * (1 << level)) {
+      return level;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the level a chunk should target given what it currently displays,
+ * applying a hysteresis band of `hysteresis` chunks on both sides of the
+ * current level's ring: while `distance` stays inside the widened ring, the
+ * chunk keeps its current level. Only when it leaves the band does the target
+ * become {@link lodLevelForDistance}. `currentLevel` and the result use `0`
+ * for full detail and `null` for "nothing displayed".
+ */
+export function resolveLodTarget(
+  distance: number,
+  currentLevel: number | null,
+  renderRadius: number,
+  maxLodLevel: number,
+  hysteresis: number,
+): number | null {
+  if (currentLevel !== null && currentLevel <= maxLodLevel) {
+    const innerRadius =
+      currentLevel === 0 ? 0 : renderRadius * (1 << (currentLevel - 1));
+    const outerRadius = renderRadius * (1 << currentLevel);
+
+    if (
+      distance > innerRadius - hysteresis &&
+      distance <= outerRadius + hysteresis
+    ) {
+      return currentLevel;
+    }
+  }
+
+  return lodLevelForDistance(distance, renderRadius, maxLodLevel);
+}
+
+/**
+ * LOD regions batch `sideInChunks x sideInChunks` chunk meshes into merged
+ * meshes. The side doubles with the level, so every ring settles at roughly
+ * the same region count — and therefore the same draw call count — no matter
+ * how far it is.
+ */
+export function lodRegionSideInChunks(level: number): number {
+  return 1 << (level + 1);
+}
+
+export function lodRegionKey(cx: number, cz: number, level: number): string {
+  const side = lodRegionSideInChunks(level);
+  return `${level}|${Math.floor(cx / side)},${Math.floor(cz / side)}`;
+}
+
+/**
+ * Everything the manager needs from the world, kept behind a narrow adapter
+ * so the manager stays testable without a live scene or network.
+ */
+export type LodChunkManagerHost = {
+  chunkSize: number;
+  renderRadius: () => number;
+  /** Resolve a geometry's material and its stable bucketing key. */
+  resolveMaterial: (
+    voxel: number,
+    faceName?: string,
+  ) => { key: string; material: Material } | null;
+  /** Apply transparent render-order / sorting setup to a merged mesh. */
+  configureTransparentMesh: (mesh: Mesh, voxel: number) => void;
+  /** Send a LOAD packet with `[x, z, level]` LOD chunk requests. */
+  requestLodChunks: (requests: [number, number, number][]) => void;
+  /** Send an UNLOAD packet releasing server-side interest. */
+  unloadChunks: (coords: Coords2[]) => void;
+  isWithinWorld: (cx: number, cz: number) => boolean;
+  /** Whether a loaded full-detail chunk currently exists for these coords. */
+  isFullChunkActive: (cx: number, cz: number) => boolean;
+  /** Dispose the full-detail form now that its LOD replacement displays. */
+  disposeFullChunk: (cx: number, cz: number) => void;
+  /** Show or hide the full-detail chunk group. */
+  setFullChunkVisible: (cx: number, cz: number, isVisible: boolean) => void;
+  /**
+   * Re-request the full form of a loaded chunk so the server's interest
+   * flips back from LOD after a discarded stale LOD arrival.
+   */
+  refreshFullChunk: (cx: number, cz: number) => void;
+};
+
+export type LodChunkManagerOptions = {
+  maxLodLevel: number;
+  hysteresis: number;
+  maxRequestsPerUpdate: number;
+  /** Updates between re-issuing an unanswered LOD request. */
+  rerequestInterval: number;
+  /** Hard clamp on the LOD horizon, in chunks. */
+  maxLodRadius: number;
+};
+
+type LodGeometryBucket = {
+  material: Material;
+  voxel: number;
+  geometries: { chunk: LodChunkState; geometry: GeometryProtocol }[];
+};
+
+type LodChunkState = {
+  name: string;
+  coords: Coords2;
+  displayedLevel: number | null;
+  geometries: GeometryProtocol[] | null;
+  requestedLevel: number | null;
+  requestedAt: number;
+};
+
+type LodRegion = {
+  key: string;
+  level: number;
+  members: Set<LodChunkState>;
+  group: Group;
+  meshes: Mesh[];
+  isDirty: boolean;
+};
+
+const SCAN_INTERVAL_UPDATES = 30;
+
+function computeFlatNormalsInto(
+  normals: Float32Array,
+  positions: Float32Array,
+  indices: Uint32Array,
+): void {
+  for (let i = 0; i < indices.length; i += 3) {
+    const ia = indices[i] * 3;
+    const ib = indices[i + 1] * 3;
+    const ic = indices[i + 2] * 3;
+    const e1x = positions[ib] - positions[ia];
+    const e1y = positions[ib + 1] - positions[ia + 1];
+    const e1z = positions[ib + 2] - positions[ia + 2];
+    const e2x = positions[ic] - positions[ia];
+    const e2y = positions[ic + 1] - positions[ia + 1];
+    const e2z = positions[ic + 2] - positions[ia + 2];
+    let nx = e1y * e2z - e1z * e2y;
+    let ny = e1z * e2x - e1x * e2z;
+    let nz = e1x * e2y - e1y * e2x;
+    const length = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    if (length > 0) {
+      nx /= length;
+      ny /= length;
+      nz /= length;
+    }
+    normals[ia] = nx;
+    normals[ia + 1] = ny;
+    normals[ia + 2] = nz;
+    normals[ib] = nx;
+    normals[ib + 1] = ny;
+    normals[ib + 2] = nz;
+    normals[ic] = nx;
+    normals[ic + 1] = ny;
+    normals[ic + 2] = nz;
+  }
+}
+
+/**
+ * Owns the lifecycle of every LOD-form chunk: requesting by distance ring,
+ * receiving meshes, batching them into region meshes, and swapping against
+ * the full-detail pipeline without ever leaving a hole or showing two forms
+ * of the same chunk in one frame. All scene mutations happen inside
+ * {@link update} so each frame observes one consistent state.
+ */
+export class LodChunkManager {
+  /** Root of all LOD region groups; the world adds this to the scene. */
+  public readonly group = new Group();
+
+  private states = new Map<string, LodChunkState>();
+  private regions = new Map<string, LodRegion>();
+
+  private updateCount = 0;
+  private lastScanUpdate = -Infinity;
+  private lastCenter: Coords2 | null = null;
+
+  private candidates: [number, number, number][] = [];
+  private pendingFullDisposals: Coords2[] = [];
+  private pendingFullReveals: Coords2[] = [];
+
+  constructor(
+    private host: LodChunkManagerHost,
+    private options: LodChunkManagerOptions,
+  ) {
+    this.group.name = "lod-chunks";
+  }
+
+  get maxLodLevel(): number {
+    return this.options.maxLodLevel;
+  }
+
+  /** The LOD horizon in chunks for the current render radius. */
+  get visualRadius(): number {
+    return Math.min(
+      this.host.renderRadius() * (1 << this.options.maxLodLevel),
+      this.options.maxLodRadius,
+    );
+  }
+
+  /** Whether the manager currently displays a LOD form for this chunk. */
+  hasDisplayedForm(cx: number, cz: number): boolean {
+    const state = this.states.get(ChunkUtils.getChunkName([cx, cz]));
+    return state?.displayedLevel != null;
+  }
+
+  /**
+   * Whether the manager tracks this chunk in any way (displayed or with an
+   * in-flight request) and therefore owns its server-side interest.
+   */
+  owns(cx: number, cz: number): boolean {
+    return this.states.has(ChunkUtils.getChunkName([cx, cz]));
+  }
+
+  get displayedCount(): number {
+    let count = 0;
+    for (const state of this.states.values()) {
+      if (state.displayedLevel !== null) count++;
+    }
+    return count;
+  }
+
+  /**
+   * Ingest a LOD chunk protocol (LOAD or UPDATE). Geometry becomes visible on
+   * the next {@link update}, at which point any older form is retired in the
+   * same frame.
+   */
+  onLodChunk(data: ChunkProtocol): void {
+    const { x, z, meshes } = data;
+    const mesh = meshes?.[0];
+    const level = mesh?.lod ?? 0;
+    if (!mesh || level < 1) return;
+
+    // A LOD mesh landing while the viewer is back inside the full-detail
+    // ring is stale (demote raced a return trip): discard it and flip the
+    // server's interest back to the full form.
+    if (this.host.isFullChunkActive(x, z) && this.lastCenter) {
+      const dx = x - this.lastCenter[0];
+      const dz = z - this.lastCenter[1];
+      const target = resolveLodTarget(
+        Math.sqrt(dx * dx + dz * dz),
+        0,
+        this.host.renderRadius(),
+        this.options.maxLodLevel,
+        this.options.hysteresis,
+      );
+
+      if (target === 0) {
+        const staleName = ChunkUtils.getChunkName([x, z]);
+        const staleState = this.states.get(staleName);
+        if (staleState && staleState.displayedLevel === null) {
+          this.states.delete(staleName);
+        } else if (staleState?.requestedLevel === level) {
+          staleState.requestedLevel = null;
+        }
+        this.host.refreshFullChunk(x, z);
+        return;
+      }
+    }
+
+    const name = ChunkUtils.getChunkName([x, z]);
+    let state = this.states.get(name);
+    if (!state) {
+      state = {
+        name,
+        coords: [x, z],
+        displayedLevel: null,
+        geometries: null,
+        requestedLevel: null,
+        requestedAt: 0,
+      };
+      this.states.set(name, state);
+    }
+
+    if (state.requestedLevel === level) {
+      state.requestedLevel = null;
+    }
+
+    if (state.displayedLevel !== null && state.displayedLevel !== level) {
+      this.removeFromRegion(state, state.displayedLevel);
+    }
+
+    state.geometries = mesh.geometries ?? [];
+    state.displayedLevel = level;
+    this.addToRegion(state, level);
+
+    // Reaching here with an active full form means this arrival is the
+    // demote replacement: the full chunk is disposed after regions rebuild.
+    if (this.host.isFullChunkActive(x, z)) {
+      this.pendingFullDisposals.push([x, z]);
+    }
+  }
+
+  /**
+   * The full-detail pipeline finished building every sub-chunk mesh of this
+   * chunk: retire the LOD form and reveal the full group on the next update,
+   * in the same frame.
+   */
+  onFullChunkDisplayable(cx: number, cz: number): void {
+    const state = this.states.get(ChunkUtils.getChunkName([cx, cz]));
+    if (!state || state.displayedLevel === null) return;
+
+    this.removeFromRegion(state, state.displayedLevel);
+    state.displayedLevel = null;
+    state.geometries = null;
+    state.requestedLevel = null;
+    this.pendingFullReveals.push([cx, cz]);
+  }
+
+  /**
+   * After a reconnect the server holds no interests: re-request every
+   * displayed LOD chunk at its current level so interest re-registers and
+   * refreshed meshes stream back in. Displayed geometry stays up meanwhile.
+   */
+  resyncForRejoin(): void {
+    for (const state of this.states.values()) {
+      if (state.displayedLevel !== null) {
+        state.requestedLevel = state.displayedLevel;
+        state.requestedAt = this.updateCount;
+        this.candidates.push([
+          state.coords[0],
+          state.coords[1],
+          state.displayedLevel,
+        ]);
+      }
+    }
+    this.flushRequests();
+  }
+
+  /**
+   * Per-frame pump: scan rings (throttled), issue requests, retire
+   * out-of-range chunks, rebuild dirty regions, then commit pending swaps —
+   * all within this call so the frame renders one consistent state.
+   */
+  update(center: Coords2): void {
+    this.updateCount++;
+
+    const centerChanged =
+      !this.lastCenter ||
+      this.lastCenter[0] !== center[0] ||
+      this.lastCenter[1] !== center[1];
+
+    if (
+      centerChanged ||
+      this.updateCount - this.lastScanUpdate >= SCAN_INTERVAL_UPDATES
+    ) {
+      this.scan(center);
+      this.lastScanUpdate = this.updateCount;
+      this.lastCenter = [center[0], center[1]];
+    }
+
+    this.flushRequests();
+    this.rebuildDirtyRegions();
+    this.commitSwaps();
+  }
+
+  dispose(): void {
+    for (const region of this.regions.values()) {
+      this.disposeRegionMeshes(region);
+      this.group.remove(region.group);
+    }
+    this.regions.clear();
+    this.states.clear();
+    this.candidates = [];
+  }
+
+  private scan(center: Coords2): void {
+    const renderRadius = this.host.renderRadius();
+    const maxLodLevel = this.options.maxLodLevel;
+    const hysteresis = this.options.hysteresis;
+    const scanRadius = Math.ceil(this.visualRadius + hysteresis);
+    const [centerX, centerZ] = center;
+
+    const requests: { cx: number; cz: number; level: number; d: number }[] = [];
+    const toRemove: LodChunkState[] = [];
+    const visited = new Set<string>();
+
+    const consider = (cx: number, cz: number, distance: number) => {
+      if (!this.host.isWithinWorld(cx, cz)) return;
+
+      const name = ChunkUtils.getChunkName([cx, cz]);
+      visited.add(name);
+      const state = this.states.get(name);
+
+      const isFullActive = this.host.isFullChunkActive(cx, cz);
+      const currentLevel =
+        state?.displayedLevel != null
+          ? state.displayedLevel
+          : isFullActive
+            ? 0
+            : null;
+
+      const target = resolveLodTarget(
+        distance,
+        currentLevel,
+        renderRadius,
+        maxLodLevel,
+        hysteresis,
+      );
+
+      if (target === null) {
+        if (state) toRemove.push(state);
+        return;
+      }
+
+      if (target === 0) {
+        // The full-detail pipeline owns requesting; the LOD form (if any)
+        // stays displayed until the full chunk reports displayable.
+        if (state?.requestedLevel != null) state.requestedLevel = null;
+        return;
+      }
+
+      if (state?.displayedLevel === target) {
+        if (state.requestedLevel != null && state.requestedLevel !== target) {
+          state.requestedLevel = null;
+        }
+        return;
+      }
+
+      if (state?.requestedLevel === target) {
+        const age = this.updateCount - state.requestedAt;
+        if (age <= this.options.rerequestInterval) return;
+      }
+
+      requests.push({ cx, cz, level: target, d: distance });
+    };
+
+    for (let ox = -scanRadius; ox <= scanRadius; ox++) {
+      for (let oz = -scanRadius; oz <= scanRadius; oz++) {
+        const distance = Math.sqrt(ox * ox + oz * oz);
+        if (distance > scanRadius) continue;
+        consider(centerX + ox, centerZ + oz, distance);
+      }
+    }
+
+    // States drifting outside the scan window (fast travel) still retire.
+    for (const state of this.states.values()) {
+      if (visited.has(state.name)) continue;
+      const dx = state.coords[0] - centerX;
+      const dz = state.coords[1] - centerZ;
+      if (Math.sqrt(dx * dx + dz * dz) > scanRadius) {
+        toRemove.push(state);
+      }
+    }
+
+    requests.sort((a, b) => a.d - b.d);
+    this.candidates = requests.map(({ cx, cz, level }) => [cx, cz, level]);
+
+    if (toRemove.length) {
+      const unloaded: Coords2[] = [];
+      for (const state of toRemove) {
+        if (state.displayedLevel !== null) {
+          this.removeFromRegion(state, state.displayedLevel);
+        }
+        this.states.delete(state.name);
+        unloaded.push(state.coords);
+      }
+      this.host.unloadChunks(unloaded);
+    }
+  }
+
+  private flushRequests(): void {
+    if (!this.candidates.length) return;
+
+    const batch = this.candidates.splice(0, this.options.maxRequestsPerUpdate);
+    const requests: [number, number, number][] = [];
+
+    for (const [cx, cz, level] of batch) {
+      const name = ChunkUtils.getChunkName([cx, cz]);
+      let state = this.states.get(name);
+      if (!state) {
+        state = {
+          name,
+          coords: [cx, cz],
+          displayedLevel: null,
+          geometries: null,
+          requestedLevel: null,
+          requestedAt: 0,
+        };
+        this.states.set(name, state);
+      }
+      state.requestedLevel = level;
+      state.requestedAt = this.updateCount;
+      requests.push([cx, cz, level]);
+    }
+
+    if (requests.length) {
+      this.host.requestLodChunks(requests);
+    }
+  }
+
+  private addToRegion(state: LodChunkState, level: number): void {
+    const key = lodRegionKey(state.coords[0], state.coords[1], level);
+    let region = this.regions.get(key);
+    if (!region) {
+      region = {
+        key,
+        level,
+        members: new Set(),
+        group: new Group(),
+        meshes: [],
+        isDirty: false,
+      };
+      region.group.name = `lod-region-${key}`;
+      this.group.add(region.group);
+      this.regions.set(key, region);
+    }
+    region.members.add(state);
+    region.isDirty = true;
+  }
+
+  private removeFromRegion(state: LodChunkState, level: number): void {
+    const key = lodRegionKey(state.coords[0], state.coords[1], level);
+    const region = this.regions.get(key);
+    if (!region) return;
+    region.members.delete(state);
+    region.isDirty = true;
+  }
+
+  private rebuildDirtyRegions(): void {
+    for (const region of this.regions.values()) {
+      if (!region.isDirty) continue;
+      region.isDirty = false;
+      this.rebuildRegion(region);
+    }
+  }
+
+  private commitSwaps(): void {
+    if (this.pendingFullDisposals.length) {
+      for (const [cx, cz] of this.pendingFullDisposals) {
+        this.host.disposeFullChunk(cx, cz);
+      }
+      this.pendingFullDisposals = [];
+    }
+
+    if (this.pendingFullReveals.length) {
+      for (const [cx, cz] of this.pendingFullReveals) {
+        this.host.setFullChunkVisible(cx, cz, true);
+      }
+      this.pendingFullReveals = [];
+    }
+  }
+
+  private disposeRegionMeshes(region: LodRegion): void {
+    for (const mesh of region.meshes) {
+      mesh.geometry.dispose();
+      region.group.remove(mesh);
+    }
+    region.meshes = [];
+  }
+
+  private rebuildRegion(region: LodRegion): void {
+    this.disposeRegionMeshes(region);
+
+    if (region.members.size === 0) {
+      this.group.remove(region.group);
+      this.regions.delete(region.key);
+      return;
+    }
+
+    const buckets = new Map<string, LodGeometryBucket>();
+
+    for (const state of region.members) {
+      if (!state.geometries) continue;
+      for (const geometry of state.geometries) {
+        if (!geometry.positions?.length || !geometry.indices?.length) {
+          continue;
+        }
+        // Isolated per-position faces cannot resolve a shared material at
+        // LOD scale; the downsampler avoids such representatives, so simply
+        // skip the rare leftover face.
+        if (geometry.at && geometry.at.length) continue;
+
+        const resolved = this.host.resolveMaterial(
+          geometry.voxel,
+          geometry.faceName ?? undefined,
+        );
+        if (!resolved) continue;
+
+        let bucket = buckets.get(resolved.key);
+        if (!bucket) {
+          bucket = {
+            material: resolved.material,
+            voxel: geometry.voxel,
+            geometries: [],
+          };
+          buckets.set(resolved.key, bucket);
+        }
+        bucket.geometries.push({ chunk: state, geometry });
+      }
+    }
+
+    const chunkSize = this.host.chunkSize;
+
+    for (const [key, bucket] of buckets) {
+      let vertexCount = 0;
+      let indexCount = 0;
+      for (const { geometry } of bucket.geometries) {
+        vertexCount += geometry.positions.length / 3;
+        indexCount += geometry.indices.length;
+      }
+      if (vertexCount === 0 || indexCount === 0) continue;
+
+      const positions = new Float32Array(vertexCount * 3);
+      const uvs = new Float32Array(vertexCount * 2);
+      const lights = new Int32Array(vertexCount);
+      const indices = new Uint32Array(indexCount);
+
+      let vertexBase = 0;
+      let indexBase = 0;
+
+      for (const { chunk, geometry } of bucket.geometries) {
+        const offsetX = chunk.coords[0] * chunkSize;
+        const offsetZ = chunk.coords[1] * chunkSize;
+        const count = geometry.positions.length / 3;
+
+        for (let i = 0; i < count; i++) {
+          positions[(vertexBase + i) * 3] = geometry.positions[i * 3] + offsetX;
+          positions[(vertexBase + i) * 3 + 1] = geometry.positions[i * 3 + 1];
+          positions[(vertexBase + i) * 3 + 2] =
+            geometry.positions[i * 3 + 2] + offsetZ;
+        }
+        uvs.set(geometry.uvs, vertexBase * 2);
+        lights.set(geometry.lights, vertexBase);
+        for (let i = 0; i < geometry.indices.length; i++) {
+          indices[indexBase + i] = geometry.indices[i] + vertexBase;
+        }
+
+        vertexBase += count;
+        indexBase += geometry.indices.length;
+      }
+
+      const normals = new Float32Array(vertexCount * 3);
+      computeFlatNormalsInto(normals, positions, indices);
+
+      const merged = new BufferGeometry();
+      merged.setAttribute("position", new BufferAttribute(positions, 3));
+      merged.setAttribute("uv", new BufferAttribute(uvs, 2));
+      merged.setAttribute("light", new BufferAttribute(lights, 1));
+      merged.setAttribute("normal", new BufferAttribute(normals, 3));
+      merged.setIndex(new BufferAttribute(indices, 1));
+      merged.computeBoundingSphere();
+
+      const mesh = new Mesh(merged, bucket.material);
+      mesh.matrixAutoUpdate = false;
+      mesh.updateMatrix();
+      mesh.userData = {
+        isLodChunk: true,
+        lodLevel: region.level,
+        materialBucket: key,
+        voxel: bucket.voxel,
+      };
+
+      if (bucket.material.transparent) {
+        this.host.configureTransparentMesh(mesh, bucket.voxel);
+      }
+
+      region.group.add(mesh);
+      region.meshes.push(mesh);
+    }
+  }
+}

--- a/packages/core/src/core/world/chunk-lod.ts
+++ b/packages/core/src/core/world/chunk-lod.ts
@@ -658,6 +658,10 @@ export class LodChunkManager {
     }
 
     const chunkSize = this.host.chunkSize;
+    // The shader tiles greedy textures per 2^level-sized cell (instead of
+    // per block) when these bits are set, so distant terrain reads as a
+    // scaled-up version of itself rather than a repeating pattern.
+    const lodLevelBits = region.level << 21;
 
     for (const [key, bucket] of buckets) {
       let vertexCount = 0;
@@ -688,7 +692,9 @@ export class LodChunkManager {
             geometry.positions[i * 3 + 2] + offsetZ;
         }
         uvs.set(geometry.uvs, vertexBase * 2);
-        lights.set(geometry.lights, vertexBase);
+        for (let i = 0; i < count; i++) {
+          lights[vertexBase + i] = geometry.lights[i] | lodLevelBits;
+        }
         for (let i = 0; i < geometry.indices.length; i++) {
           indices[indexBase + i] = geometry.indices[i] + vertexBase;
         }

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "events";
 import { AABB } from "@voxelize/aabb";
 import { Engine as PhysicsEngine } from "@voxelize/physics-engine";
 import {
+  ChunkProtocol,
   EntityOperation,
   EntityProtocol,
   GeometryProtocol,
@@ -134,6 +135,7 @@ import {
   PY_ROTATION,
 } from "./block";
 import { Chunk } from "./chunk";
+import { LodChunkManager } from "./chunk-lod";
 import { ChunkRenderer, makeSceneColorTexture } from "./chunk-renderer";
 import {
   ChunkRequestCandidate,
@@ -157,6 +159,7 @@ import MeshWorker from "./workers/mesh-worker.ts?worker";
 
 export * from "./block";
 export * from "./chunk";
+export * from "./chunk-lod";
 export * from "./chunk-renderer";
 export * from "./chunk-requests";
 export * from "./clouds";
@@ -504,6 +507,31 @@ export type WorldClientOptions = {
    * Whether to merge chunk geometries to reduce draw calls. Useful for mobile. Defaults to false.
    */
   mergeChunkGeometries: boolean;
+
+  /**
+   * Whether to render distant chunks as reduced-detail meshes when the world
+   * (server-side) has `chunk_lod` enabled. Has no effect on worlds that did
+   * not opt in. Defaults to `true`.
+   */
+  isLodEnabled: boolean;
+
+  /**
+   * Maximum LOD chunk requests sent per update. Defaults to `24`.
+   */
+  maxLodRequestsPerUpdate: number;
+
+  /**
+   * Hysteresis band width, in chunks, around every LOD ring boundary. A chunk
+   * keeps its current detail level until it moves this many chunks past the
+   * boundary, preventing thrash while hovering on a ring edge. Defaults to `1`.
+   */
+  lodHysteresis: number;
+
+  /**
+   * Hard clamp on the LOD horizon, in chunks, regardless of
+   * `renderRadius * 2^maxLevel`. Defaults to `96`.
+   */
+  maxLodRadius: number;
 };
 
 const defaultOptions: WorldClientOptions = {
@@ -534,6 +562,10 @@ const defaultOptions: WorldClientOptions = {
   lightJobRetryLimit: 3,
   deltaRetentionTime: 5000,
   mergeChunkGeometries: false,
+  isLodEnabled: true,
+  maxLodRequestsPerUpdate: 24,
+  lodHysteresis: 1,
+  maxLodRadius: 96,
 };
 
 /**
@@ -606,6 +638,13 @@ export type WorldServerOptions = {
    * The nominal water level of this world, in blocks.
    */
   waterLevel: number;
+
+  /**
+   * Level-of-detail configuration of this world, present only when the
+   * server enabled `chunk_lod`. Distant chunks are then served as compact
+   * meshes downsampled by `2^level`, for levels `1..maxLevel`.
+   */
+  chunkLod?: { maxLevel: number } | null;
 };
 
 /**
@@ -921,7 +960,8 @@ export class World<T = any> extends Scene implements NetIntercept {
     }
   > = new Map();
   private blockEntityUpdateListeners = new Set<BlockEntityUpdateListener<T>>();
-  private deferredBlockEntityUpdates = new DeferredBlockEntityUpdateController();
+  private deferredBlockEntityUpdates =
+    new DeferredBlockEntityUpdateController();
 
   private blockUpdateListeners = new Set<BlockUpdateListener>();
 
@@ -935,6 +975,17 @@ export class World<T = any> extends Scene implements NetIntercept {
   // must be re-established after a rejoin, drained through the paced
   // chunk-request flow.
   private chunkRefreshQueue = new Set<string>();
+
+  /**
+   * Renders distant chunks as reduced-detail meshes. Only instantiated when
+   * the server world enabled `chunk_lod` and `options.isLodEnabled` is true;
+   * `null` otherwise, at zero cost.
+   */
+  private lodManager: LodChunkManager | null = null;
+
+  // The chunk-grid center of the last `update` call, used by LOD request
+  // packets issued between updates.
+  private lastUpdateCenter: Coords2 = [0, 0];
 
   public extraInitData: Record<string, unknown> = {};
 
@@ -1248,6 +1299,7 @@ export class World<T = any> extends Scene implements NetIntercept {
     };
 
     this.buildChunkMesh(cx, cz, mesh);
+    this.maybeRetireLodForm(cx, cz);
 
     const chunk = this.getChunkByCoords(cx, cz);
     if (chunk) {
@@ -1266,6 +1318,24 @@ export class World<T = any> extends Scene implements NetIntercept {
         allMeshes: chunk.meshes,
         reason: "voxel",
       });
+    }
+  }
+
+  /**
+   * Once every sub-chunk level of a chunk has a built mesh, its full-detail
+   * form can replace the LOD stand-in. The manager commits the swap (reveal
+   * full, drop LOD) atomically inside its next update.
+   */
+  private maybeRetireLodForm(cx: number, cz: number) {
+    if (!this.lodManager?.hasDisplayedForm(cx, cz)) return;
+
+    const chunk = this.getChunkByCoords(cx, cz);
+    if (!chunk || !chunk.isReady) return;
+
+    if (
+      this.meshPipeline.hasDisplayedAllLevels(cx, cz, this.options.subChunks)
+    ) {
+      this.lodManager.onFullChunkDisplayable(cx, cz);
     }
   }
 
@@ -3766,12 +3836,87 @@ export class World<T = any> extends Scene implements NetIntercept {
     this.lightWorkerPool.postMessage({ type: "init", registryData });
 
     this.isInitialized = true;
+    this.setupLodManager();
     this.renderRadius = this.options.defaultRenderRadius;
 
     if (this.initialEntities) {
       this.handleEntities(this.initialEntities);
       this.initialEntities = null;
     }
+  }
+
+  private setupLodManager() {
+    const chunkLod = this.options.chunkLod;
+    if (!chunkLod || chunkLod.maxLevel < 1 || !this.options.isLodEnabled) {
+      return;
+    }
+
+    this.lodManager = new LodChunkManager(
+      {
+        chunkSize: this.options.chunkSize,
+        renderRadius: () => this._renderRadius,
+        resolveMaterial: (voxel, faceName) => {
+          const material = this.getBlockFaceMaterial(voxel, faceName);
+          if (!material) return null;
+          return {
+            key: this.makeChunkMaterialKey(voxel, faceName),
+            material,
+          };
+        },
+        configureTransparentMesh: (mesh, voxel) => {
+          this.configureTransparentChunkMesh(
+            mesh,
+            voxel,
+            mesh.material as CustomChunkShaderMaterial,
+          );
+        },
+        requestLodChunks: (lodChunks) => {
+          this.packets.push({
+            type: "LOAD",
+            json: {
+              center: this.lastUpdateCenter,
+              direction: [0, 0],
+              chunks: [],
+              lodChunks,
+            },
+          });
+        },
+        unloadChunks: (chunks) => {
+          if (chunks.length) {
+            this.packets.push({ type: "UNLOAD", json: { chunks } });
+          }
+        },
+        isWithinWorld: (cx, cz) => this.isWithinWorld(cx, cz),
+        isFullChunkActive: (cx, cz) => !!this.getChunkByCoords(cx, cz),
+        disposeFullChunk: (cx, cz) => {
+          const name = ChunkUtils.getChunkName([cx, cz]);
+          const chunk = this.chunkPipeline.getLoadedChunk(name);
+          if (chunk) {
+            // The server already switched this client's interest to the LOD
+            // form when it answered the LOD request, so no UNLOAD is sent.
+            this.disposeLoadedChunk(chunk, name, { isUnloadSent: false });
+          }
+        },
+        setFullChunkVisible: (cx, cz, isVisible) => {
+          const chunk = this.getChunkByCoords(cx, cz);
+          if (chunk) {
+            chunk.group.visible = isVisible;
+          }
+        },
+        refreshFullChunk: (cx, cz) => {
+          this.chunkRefreshQueue.add(ChunkUtils.getChunkName([cx, cz]));
+        },
+      },
+      {
+        maxLodLevel: chunkLod.maxLevel,
+        hysteresis: this.options.lodHysteresis,
+        maxRequestsPerUpdate: this.options.maxLodRequestsPerUpdate,
+        rerequestInterval: this.options.chunkRerequestInterval,
+        maxLodRadius: this.options.maxLodRadius,
+      },
+    );
+
+    this.add(this.lodManager.group);
   }
   update(
     position: Vector3 = new Vector3(),
@@ -3788,6 +3933,7 @@ export class World<T = any> extends Scene implements NetIntercept {
       position.toArray() as Coords3,
       this.options.chunkSize,
     );
+    this.lastUpdateCenter = center;
     if (this.options.doesTickTime) {
       this._time = (this.time + delta) % this.options.timePerDay;
     }
@@ -3800,6 +3946,7 @@ export class World<T = any> extends Scene implements NetIntercept {
 
     const startRequestChunks = performance.now();
     this.requestChunks(center, direction);
+    this.lodManager?.update(center);
     const requestChunksDuration = performance.now() - startRequestChunks;
 
     const startProcessChunks = performance.now();
@@ -3873,6 +4020,7 @@ export class World<T = any> extends Scene implements NetIntercept {
         // immediately instead of idling until the rerequest interval.
         if (this.isInitialized) {
           this.resyncChunkStagesAfterRejoin();
+          this.lodManager?.resyncForRejoin();
         }
 
         break;
@@ -3905,6 +4053,11 @@ export class World<T = any> extends Scene implements NetIntercept {
       case "LOAD": {
         const { chunks } = message;
         chunks.forEach((chunk) => {
+          if (this.isLodChunkProtocol(chunk)) {
+            this.lodManager?.onLodChunk(chunk);
+            return;
+          }
+
           const { x, z } = chunk;
           this.chunkPipeline.markProcessing([x, z], "load", chunk);
         });
@@ -3912,10 +4065,20 @@ export class World<T = any> extends Scene implements NetIntercept {
         break;
       }
       case "UPDATE": {
-        const { updates } = message;
+        const { updates, chunks } = message;
 
         if (updates && updates.length > 0) {
           this.applyServerUpdatesImmediately(updates);
+        }
+
+        // Voxel edits inside a chunk this client views as LOD arrive as a
+        // rebuilt reduced-detail mesh.
+        if (chunks && chunks.length > 0) {
+          chunks.forEach((chunk) => {
+            if (this.isLodChunkProtocol(chunk)) {
+              this.lodManager?.onLodChunk(chunk);
+            }
+          });
         }
 
         break;
@@ -4053,7 +4216,13 @@ export class World<T = any> extends Scene implements NetIntercept {
 
   getBaseFogRange(): WorldFogRange {
     const { chunkSize, fogNearRenderRatio, fogFarRenderRatio } = this.options;
-    const renderDistance = this._renderRadius * chunkSize;
+
+    // With LOD active the visible horizon extends far beyond the full-detail
+    // radius, so fog tracks the LOD horizon instead of hiding the rings.
+    const visualRadius = this.lodManager
+      ? this.lodManager.visualRadius
+      : this._renderRadius;
+    const renderDistance = visualRadius * chunkSize;
 
     return {
       near: renderDistance * fogNearRenderRatio,
@@ -4255,6 +4424,7 @@ export class World<T = any> extends Scene implements NetIntercept {
             this.buildChunkMesh(x, z, mesh);
             this.meshPipeline.markFreshFromServer(x, z, mesh.level);
           }
+          this.maybeRetireLodForm(x, z);
         }
       };
       if (chunk.isReady) {
@@ -4268,6 +4438,10 @@ export class World<T = any> extends Scene implements NetIntercept {
         });
       }
     });
+  }
+
+  private isLodChunkProtocol(chunk: ChunkProtocol) {
+    return !!chunk.meshes?.length && (chunk.meshes[0].lod ?? 0) >= 1;
   }
 
   private isChunkReadyForEntityUpdates(
@@ -4312,47 +4486,81 @@ export class World<T = any> extends Scene implements NetIntercept {
     }
   }
 
+  /**
+   * Tear down a loaded chunk: events, block entities, scene group, data, and
+   * pipeline records. When `isUnloadSent` is false the server keeps its
+   * (already-downgraded) interest — used when a LOD form replaces the chunk.
+   */
+  private disposeLoadedChunk(
+    chunk: Chunk,
+    name: string,
+    { isUnloadSent }: { isUnloadSent: boolean },
+  ) {
+    const [x, z] = chunk.coords;
+
+    chunk.meshes.forEach((meshes, level) => {
+      for (const mesh of meshes) {
+        if (mesh) {
+          this.csmRenderer?.removeSkipShadowObject(mesh);
+        }
+      }
+      this.emitChunkEvent("chunk-mesh-unloaded", {
+        chunk,
+        coords: chunk.coords,
+        level,
+        meshes,
+      });
+    });
+
+    this.emitChunkEvent("chunk-unloaded", {
+      chunk,
+      coords: chunk.coords,
+      allMeshes: new Map(chunk.meshes),
+    });
+
+    this.pruneBlockEntitiesInChunk(chunk.coords);
+    this.remove(chunk.group);
+    chunk.group.visible = true;
+    chunk.dispose();
+    this.meshPipeline.remove(x, z);
+    this.chunkPipeline.remove(name);
+    this.chunkInitializeListeners.delete(name);
+    this.deferredBlockEntityUpdates.cancelChunk(name);
+
+    if (isUnloadSent) {
+      this.packets.push({
+        type: "UNLOAD",
+        json: { chunks: [chunk.coords] },
+      });
+    }
+  }
+
   private maintainChunks(center: Coords2) {
     const { deleteRadius } = this;
 
     const [centerX, centerZ] = center;
     const deleted: Coords2[] = [];
-    const toRemove: string[] = [];
 
+    // With LOD active, loaded chunks inside the LOD horizon are retired by
+    // the demote flow instead (disposed only once their reduced-detail
+    // replacement is displayable), so walking away never opens holes.
+    const dataDeleteRadius = this.lodManager
+      ? Math.max(deleteRadius, this.lodManager.visualRadius * 1.1)
+      : deleteRadius;
+
+    const loadedToDispose: { chunk: Chunk; name: string }[] = [];
     this.chunkPipeline.forEachLoaded((chunk, name) => {
       const [x, z] = chunk.coords;
 
-      if ((x - centerX) ** 2 + (z - centerZ) ** 2 > deleteRadius ** 2) {
-        chunk.meshes.forEach((meshes, level) => {
-          for (const mesh of meshes) {
-            if (mesh) {
-              this.csmRenderer?.removeSkipShadowObject(mesh);
-            }
-          }
-          this.emitChunkEvent("chunk-mesh-unloaded", {
-            chunk,
-            coords: chunk.coords,
-            level,
-            meshes,
-          });
-        });
-
-        this.emitChunkEvent("chunk-unloaded", {
-          chunk,
-          coords: chunk.coords,
-          allMeshes: new Map(chunk.meshes),
-        });
-
-        this.pruneBlockEntitiesInChunk(chunk.coords);
-        this.remove(chunk.group);
-        chunk.dispose();
-        this.meshPipeline.remove(x, z);
-        toRemove.push(name);
-        deleted.push(chunk.coords);
+      if ((x - centerX) ** 2 + (z - centerZ) ** 2 > dataDeleteRadius ** 2) {
+        loadedToDispose.push({ chunk, name });
       }
     });
 
-    toRemove.forEach((name) => this.chunkPipeline.remove(name));
+    for (const { chunk, name } of loadedToDispose) {
+      this.disposeLoadedChunk(chunk, name, { isUnloadSent: false });
+      deleted.push(chunk.coords);
+    }
 
     this.chunkPipeline.forEach("requested", (name) => {
       const [x, z] = ChunkUtils.parseChunkName(name);
@@ -4381,11 +4589,18 @@ export class World<T = any> extends Scene implements NetIntercept {
       this.deferredBlockEntityUpdates.cancelChunk(name);
     });
 
-    if (deleted.length) {
+    // Chunks the LOD manager tracks keep their server-side interest — the
+    // manager owns (and re-forms) it; an UNLOAD here would tear down the LOD
+    // stream it just negotiated.
+    const toUnload = this.lodManager
+      ? deleted.filter(([x, z]) => !this.lodManager.owns(x, z))
+      : deleted;
+
+    if (toUnload.length) {
       this.packets.push({
         type: "UNLOAD",
         json: {
-          chunks: deleted,
+          chunks: toUnload,
         },
       });
     }
@@ -4950,6 +5165,14 @@ export class World<T = any> extends Scene implements NetIntercept {
 
     if (!this.children.includes(chunk.group)) {
       this.add(chunk.group);
+    }
+
+    // While a LOD stand-in still displays for this chunk, its full-detail
+    // meshes build hidden: coarse and fine surfaces can be coplanar (flat
+    // terrain), so showing both would z-fight. The LOD manager reveals the
+    // group atomically once every sub-chunk level is built.
+    if (this.lodManager?.hasDisplayedForm(cx, cz)) {
+      chunk.group.visible = false;
     }
 
     if (!chunk.meshes.has(level)) {
@@ -6048,7 +6271,10 @@ export class World<T = any> extends Scene implements NetIntercept {
     });
   }
 
-  private handleLightJobResult(job: LightJob, result: LightWorkerResult | null) {
+  private handleLightJobResult(
+    job: LightJob,
+    result: LightWorkerResult | null,
+  ) {
     if (
       !this.activeLightBatch ||
       this.activeLightBatch.batchId !== job.batchId

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -181,6 +181,10 @@ export * from "./water-optics";
 const warnedUnknownBlockIds = new Set<number>();
 const warnedUnloadedUpdateChunks = new Set<string>();
 
+// Minimum updates between two rebuilds of the same LOD region, so streams of
+// chunk arrivals into one region batch into few re-merges.
+const LOD_REGION_REBUILD_COOLDOWN_UPDATES = 10;
+
 export type TextureInfo = {
   blockId: number;
   blockName: string;
@@ -521,6 +525,14 @@ export type WorldClientOptions = {
   maxLodRequestsPerUpdate: number;
 
   /**
+   * Maximum LOD region meshes re-merged and uploaded per update. This
+   * throttles the main-thread cost of ring transitions: chunks whose region
+   * has not been rebuilt yet simply keep their previous form for a few more
+   * frames. Defaults to `2`.
+   */
+  maxLodRegionRebuildsPerUpdate: number;
+
+  /**
    * Hysteresis band width, in chunks, around every LOD ring boundary. A chunk
    * keeps its current detail level until it moves this many chunks past the
    * boundary, preventing thrash while hovering on a ring edge. Defaults to `1`.
@@ -564,6 +576,7 @@ const defaultOptions: WorldClientOptions = {
   mergeChunkGeometries: false,
   isLodEnabled: true,
   maxLodRequestsPerUpdate: 24,
+  maxLodRegionRebuildsPerUpdate: 2,
   lodHysteresis: 1,
   maxLodRadius: 96,
 };
@@ -3944,6 +3957,8 @@ export class World<T = any> extends Scene implements NetIntercept {
         maxRequestsPerUpdate: this.options.maxLodRequestsPerUpdate,
         rerequestInterval: this.options.chunkRerequestInterval,
         maxLodRadius: this.options.maxLodRadius,
+        maxRegionRebuildsPerUpdate: this.options.maxLodRegionRebuildsPerUpdate,
+        regionRebuildCooldown: LOD_REGION_REBUILD_COOLDOWN_UPDATES,
       },
     );
 

--- a/packages/core/src/core/world/index.ts
+++ b/packages/core/src/core/world/index.ts
@@ -912,6 +912,29 @@ export class World<T = any> extends Scene implements NetIntercept {
   }
 
   /**
+   * Transparent setup for merged LOD region meshes: render order and water
+   * refraction capture only. Per-triangle distance sorting is skipped —
+   * distant merged geometry gains nothing from it and would pay a per-frame
+   * sort over a whole region — and the CSM skip-list is left alone since
+   * region meshes are rebuilt (and disposed) far too often to keep a
+   * registry entry alive.
+   */
+  private configureLodTransparentMesh(mesh: Mesh, voxel: number) {
+    const block = this.getBlockByIdSafe(voxel);
+    const isFluid = block?.isFluid ?? false;
+
+    mesh.renderOrder = isFluid
+      ? TRANSPARENT_FLUID_RENDER_ORDER
+      : TRANSPARENT_RENDER_ORDER;
+
+    if (isFluid) {
+      mesh.onBeforeRender = (renderer) => {
+        this.captureWaterRefraction(renderer);
+      };
+    }
+  }
+
+  /**
    * Whether or not this world is connected to the server and initialized with data from the server.
    */
   public isInitialized = false;
@@ -3858,17 +3881,25 @@ export class World<T = any> extends Scene implements NetIntercept {
         resolveMaterial: (voxel, faceName) => {
           const material = this.getBlockFaceMaterial(voxel, faceName);
           if (!material) return null;
+
+          // The bucket key must mirror the material's identity: only
+          // independent faces own a per-face material — every other face of
+          // a block (e.g. the mesher's per-face fluid geometries) shares one
+          // material and must merge into one bucket.
+          const block = this.getBlockByIdSafe(voxel);
+          const isIndependentFace =
+            !!faceName && !!block?.independentFaces.has(faceName);
+
           return {
-            key: this.makeChunkMaterialKey(voxel, faceName),
+            key: this.makeChunkMaterialKey(
+              voxel,
+              isIndependentFace ? faceName : undefined,
+            ),
             material,
           };
         },
         configureTransparentMesh: (mesh, voxel) => {
-          this.configureTransparentChunkMesh(
-            mesh,
-            voxel,
-            mesh.material as CustomChunkShaderMaterial,
-          );
+          this.configureLodTransparentMesh(mesh, voxel);
         },
         requestLodChunks: (lodChunks) => {
           this.packets.push({

--- a/packages/core/src/core/world/pipelines.ts
+++ b/packages/core/src/core/world/pipelines.ts
@@ -173,6 +173,13 @@ interface MeshState {
   generation: number;
   inFlightGenerations: Set<number>;
   displayedGeneration: number;
+  /**
+   * Whether a mesh result (possibly empty) has ever been applied for this
+   * key — either built locally or accepted fresh from the server. Level-of-
+   * detail swaps use this to know when a chunk's full-detail form is
+   * complete enough to replace its LOD stand-in.
+   */
+  hasDisplayed: boolean;
 }
 
 export class MeshPipeline {
@@ -187,6 +194,7 @@ export class MeshPipeline {
         generation: 0,
         inFlightGenerations: new Set(),
         displayedGeneration: 0,
+        hasDisplayed: false,
       };
       this.states.set(key, state);
     }
@@ -244,6 +252,7 @@ export class MeshPipeline {
     }
 
     state.displayedGeneration = jobGeneration;
+    state.hasDisplayed = true;
     return true;
   }
 
@@ -267,19 +276,25 @@ export class MeshPipeline {
 
   markFreshFromServer(cx: number, cz: number, level: number): void {
     const key = MeshPipeline.makeKey(cx, cz, level);
-    let state = this.states.get(key);
-    if (!state) {
-      state = {
-        generation: 0,
-        inFlightGenerations: new Set(),
-        displayedGeneration: 0,
-      };
-      this.states.set(key, state);
-    }
+    const state = this.getOrCreate(key);
     state.displayedGeneration = state.generation;
+    state.hasDisplayed = true;
     state.inFlightGenerations.clear();
     this.dirty.delete(key);
     this.urgentDirty.delete(key);
+  }
+
+  /**
+   * Whether every sub-chunk level of this chunk has had a mesh result
+   * applied at least once — i.e. the chunk's full-detail form is visually
+   * complete (some levels may legitimately be empty).
+   */
+  hasDisplayedAllLevels(cx: number, cz: number, subChunks: number): boolean {
+    for (let level = 0; level < subChunks; level++) {
+      const state = this.states.get(MeshPipeline.makeKey(cx, cz, level));
+      if (!state?.hasDisplayed) return false;
+    }
+    return true;
   }
 
   getDirtyKeys(): string[] {

--- a/packages/core/src/core/world/shaders.ts
+++ b/packages/core/src/core/world/shaders.ts
@@ -115,6 +115,7 @@ attribute int light;
 varying float vAO;
 varying float vIsFluid;
 varying float vIsGreedy;
+varying float vLodTileScale;
 varying vec4 vLight;
 varying vec4 vWorldPosition;
 varying vec3 vWorldNormal;
@@ -155,10 +156,16 @@ ${SIMPLEX_NOISE_GLSL}
 int ao = (light >> 16) & 0x3;
 int isFluid = (light >> 18) & 0x1;
 int isGreedy = (light >> 19) & 0x1;
+// Bits 21..23 carry the LOD level of reduced-detail chunk meshes (0 for
+// full-detail geometry): textures tile per 2^level-sized cell so distant
+// terrain reads as a scaled-up version of itself instead of a
+// high-frequency repeating pattern.
+int lodLevel = (light >> 21) & 0x7;
 
 vAO = uAOTable[ao] / 255.0;
 vIsFluid = float(isFluid);
 vIsGreedy = float(isGreedy);
+vLodTileScale = float(1 << lodLevel);
 vLight = unpackLight(light & 0xFFFF);
 `,
     )
@@ -247,6 +254,7 @@ uniform float uShadowDebugMode;
 varying float vAO;
 varying float vIsFluid;
 varying float vIsGreedy;
+varying float vLodTileScale;
 varying vec4 vLight;
 varying vec4 vWorldPosition;
 varying vec3 vWorldNormal;
@@ -427,25 +435,30 @@ float getShadow() {
     float cellSize = 1.0 / uAtlasSize;
     float padding = cellSize / 4.0;
     
+    // World position in texture-tile units: one tile per block at full
+    // detail, one tile per 2^lod-sized cell on LOD meshes, keeping texture
+    // scale locked to geometry scale.
+    vec3 tilePosition = vWorldPosition.xyz / vLodTileScale;
+    
     vec3 absNormal = abs(vWorldNormal);
     vec2 localUv;
     if (absNormal.y > 0.5) {
       if (vWorldNormal.y > 0.0) {
-        localUv = vec2(1.0 - fract(vWorldPosition.x), fract(vWorldPosition.z));
+        localUv = vec2(1.0 - fract(tilePosition.x), fract(tilePosition.z));
       } else {
-        localUv = vec2(fract(vWorldPosition.x), 1.0 - fract(vWorldPosition.z));
+        localUv = vec2(fract(tilePosition.x), 1.0 - fract(tilePosition.z));
       }
     } else if (absNormal.x > 0.5) {
       if (vWorldNormal.x > 0.0) {
-        localUv = vec2(1.0 - fract(vWorldPosition.z), fract(vWorldPosition.y));
+        localUv = vec2(1.0 - fract(tilePosition.z), fract(tilePosition.y));
       } else {
-        localUv = vec2(fract(vWorldPosition.z), fract(vWorldPosition.y));
+        localUv = vec2(fract(tilePosition.z), fract(tilePosition.y));
       }
     } else {
       if (vWorldNormal.z > 0.0) {
-        localUv = vec2(fract(vWorldPosition.x), fract(vWorldPosition.y));
+        localUv = vec2(fract(tilePosition.x), fract(tilePosition.y));
       } else {
-        localUv = vec2(1.0 - fract(vWorldPosition.x), fract(vWorldPosition.y));
+        localUv = vec2(1.0 - fract(tilePosition.x), fract(tilePosition.y));
       }
     }
     

--- a/packages/protocol/src/mesh-lod-codegen.test.ts
+++ b/packages/protocol/src/mesh-lod-codegen.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { protocol } from "./protocol";
+
+const { Message, Mesh } = protocol;
+
+/**
+ * Guards the generated protobuf output against a stale regen: the `Mesh.lod`
+ * field must survive a real encode/decode round-trip. A skipped
+ * `pnpm run proto` after editing messages.proto historically dropped fields
+ * silently — this test fails loudly instead.
+ */
+describe("Mesh.lod wire round-trip", () => {
+  it("preserves the lod field through encode/decode", () => {
+    const message = Message.create({
+      type: Message.Type.LOAD,
+      chunks: [
+        {
+          x: 4,
+          z: -2,
+          id: "lod-chunk",
+          meshes: [
+            {
+              level: 0,
+              lod: 2,
+              geometries: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    const encoded = Message.encode(message).finish();
+    const decoded = Message.decode(encoded);
+
+    expect(decoded.chunks).toHaveLength(1);
+    expect(decoded.chunks[0].meshes).toHaveLength(1);
+    expect(decoded.chunks[0].meshes[0].lod).toBe(2);
+    expect(decoded.chunks[0].meshes[0].level).toBe(0);
+  });
+
+  it("defaults lod to 0 for full-detail meshes from older servers", () => {
+    const legacy = Message.encode(
+      Message.create({
+        type: Message.Type.LOAD,
+        chunks: [{ x: 0, z: 0, id: "full", meshes: [{ level: 3 }] }],
+      }),
+    ).finish();
+
+    const decoded = Message.toObject(Message.decode(legacy), {
+      defaults: true,
+    });
+
+    expect(decoded.chunks[0].meshes[0].lod).toBe(0);
+    expect(decoded.chunks[0].meshes[0].level).toBe(3);
+  });
+
+  it("keeps the generated Mesh type in sync with the schema", () => {
+    const mesh = Mesh.create({ level: 1, lod: 3 });
+    expect(mesh.lod).toBe(3);
+  });
+});

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -37,6 +37,12 @@ export type GeometryProtocol = {
 export type MeshProtocol = {
   level: number;
   geometries: GeometryProtocol[];
+  /**
+   * Level of detail this mesh was built at. `0` (or absent) is a full-detail
+   * sub-chunk mesh; `L >= 1` is a whole-column chunk mesh downsampled by
+   * `2^L`, carrying no voxel or light data alongside it.
+   */
+  lod?: number;
 };
 
 export type ChunkProtocol = {

--- a/server/server/models.rs
+++ b/server/server/models.rs
@@ -97,6 +97,9 @@ pub struct GeometryProtocol {
 #[derive(Debug, Clone, Default)]
 pub struct MeshProtocol {
     pub level: i32,
+    /// Level of detail: 0 is a full-detail sub-chunk mesh, `L >= 1` a
+    /// whole-column mesh downsampled by `2^L`.
+    pub lod: u32,
     pub geometries: Vec<GeometryProtocol>,
 }
 
@@ -309,6 +312,7 @@ impl MessageBuilder {
                         .into_iter()
                         .map(|mesh| protocols::Mesh {
                             level: mesh.level,
+                            lod: mesh.lod,
                             geometries: mesh
                                 .geometries
                                 .into_iter()

--- a/server/world/chunk_lod.rs
+++ b/server/world/chunk_lod.rs
@@ -1,0 +1,103 @@
+//! Opt-in level-of-detail (LOD) chunk meshing for distant terrain.
+//!
+//! When a world enables [`ChunkLodConfig`], the server builds a small pyramid
+//! of reduced-detail meshes for every chunk alongside its normal meshing work
+//! (see `crates/mesher/src/lod.rs` for the meshing and seam strategy).
+//! Clients then request distant chunks *as LOD meshes only* — a few kilobytes
+//! of geometry instead of full voxel + light data — extending the visible
+//! horizon to `render_radius * 2^max_level` chunks while triangle count grows
+//! only linearly with `max_level`.
+//!
+//! Everything is opt-in: with the default `None`, no pyramid is built, no LOD
+//! requests are honored, and no wire traffic changes.
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for LOD chunk meshing. Enable through
+/// [`WorldConfigBuilder::chunk_lod`](super::WorldConfigBuilder::chunk_lod).
+///
+/// Detail levels halve linear resolution per step: level `L` collapses
+/// `2^L`-sized voxel cells into single cubes. Clients map distance to level
+/// geometrically — full detail up to their render radius `R`, level `L` for
+/// distances in `(R * 2^(L-1), R * 2^L]` — so each ring roughly doubles the
+/// view distance for a near-constant triangle budget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChunkLodConfig {
+    /// Highest LOD level to build and serve, in `1..=4`. The mesh pyramid
+    /// holds levels `1..=max_level`; level `L` downsamples by `2^L` (level 4
+    /// collapses a whole 16-block chunk column slice into single cells).
+    pub max_level: u32,
+}
+
+impl Default for ChunkLodConfig {
+    fn default() -> Self {
+        Self { max_level: 2 }
+    }
+}
+
+impl ChunkLodConfig {
+    /// Validate against the world's chunk dimensions. Every level's
+    /// downsample factor must divide both the chunk size and the max height
+    /// so coarse grids align exactly with chunk borders — the seam guarantees
+    /// depend on that alignment.
+    pub fn validate(&self, chunk_size: usize, max_height: usize) -> Result<(), String> {
+        if self.max_level < 1 || self.max_level > 4 {
+            return Err(format!(
+                "max_level must be in 1..=4, got {}",
+                self.max_level
+            ));
+        }
+
+        let factor = 1usize << self.max_level;
+        if chunk_size % factor != 0 {
+            return Err(format!(
+                "chunk_size {} must be divisible by 2^max_level = {}",
+                chunk_size, factor
+            ));
+        }
+        if max_height % factor != 0 {
+            return Err(format!(
+                "max_height {} must be divisible by 2^max_level = {}",
+                max_height, factor
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// The LOD levels this config builds, lowest (finest) first.
+    pub fn levels(&self) -> impl Iterator<Item = u32> {
+        1..=self.max_level
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_two_levels() {
+        assert_eq!(ChunkLodConfig::default().max_level, 2);
+    }
+
+    #[test]
+    fn validates_divisibility() {
+        let config = ChunkLodConfig { max_level: 4 };
+        assert!(config.validate(16, 256).is_ok());
+        assert!(config.validate(12, 256).is_err());
+        assert!(config.validate(16, 100).is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_levels() {
+        assert!(ChunkLodConfig { max_level: 0 }.validate(16, 256).is_err());
+        assert!(ChunkLodConfig { max_level: 5 }.validate(16, 256).is_err());
+    }
+
+    #[test]
+    fn levels_iterates_finest_first() {
+        let config = ChunkLodConfig { max_level: 3 };
+        assert_eq!(config.levels().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+}

--- a/server/world/components/chunk_requests.rs
+++ b/server/world/components/chunk_requests.rs
@@ -10,6 +10,11 @@ pub struct ChunkRequestsComp {
     // a 2d unit vector
     pub direction: Vec2<f32>,
     pub requests: Vec<Vec2<i32>>,
+    /// Chunks requested as reduced-detail meshes, with the LOD level per
+    /// chunk. Only populated for worlds that enable `chunk_lod`. A chunk is
+    /// requested in at most one form at a time: adding a LOD request drops
+    /// any pending full request for the same coords and vice versa.
+    pub lod_requests: Vec<(Vec2<i32>, u32)>,
 }
 
 impl ChunkRequestsComp {
@@ -30,6 +35,8 @@ impl ChunkRequestsComp {
 
     /// Add a chunk to the list of chunks requested.
     pub fn add(&mut self, coords: &Vec2<i32>) {
+        self.lod_requests.retain(|(c, _)| c != coords);
+
         if self.requests.contains(coords) {
             return;
         }
@@ -37,17 +44,26 @@ impl ChunkRequestsComp {
         self.requests.push(coords.to_owned());
     }
 
-    pub fn sort(&mut self) {
-        self.requests.sort_by(|a, b| {
-            let a_dist = (a.0 - self.center.0).abs() + (a.1 - self.center.1).abs();
-            let b_dist = (b.0 - self.center.0).abs() + (b.1 - self.center.1).abs();
-
-            a_dist.cmp(&b_dist)
-        });
+    /// Add a chunk to the list of chunks requested as a LOD mesh.
+    pub fn add_lod(&mut self, coords: &Vec2<i32>, level: u32) {
+        self.requests.retain(|c| c != coords);
+        self.lod_requests.retain(|(c, _)| c != coords);
+        self.lod_requests.push((coords.to_owned(), level));
     }
 
-    /// Remove a chunk from the list of chunks requested.
+    pub fn sort(&mut self) {
+        let center = self.center.to_owned();
+        let distance =
+            |coords: &Vec2<i32>| (coords.0 - center.0).abs() + (coords.1 - center.1).abs();
+
+        self.requests.sort_by(|a, b| distance(a).cmp(&distance(b)));
+        self.lod_requests
+            .sort_by(|(a, _), (b, _)| distance(a).cmp(&distance(b)));
+    }
+
+    /// Remove a chunk from the list of chunks requested, in either form.
     pub fn remove(&mut self, coords: &Vec2<i32>) {
         self.requests.retain(|c| c != coords);
+        self.lod_requests.retain(|(c, _)| c != coords);
     }
 }

--- a/server/world/config.rs
+++ b/server/world/config.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+use super::chunk_lod::ChunkLodConfig;
 use super::fixed_step::FixedStepConfig;
 use super::generators::NoiseOptions;
 use super::lag_comp::LagCompConfig;
@@ -189,6 +190,14 @@ pub struct WorldConfig {
     /// tick-anchored; a `Some` here without a fixed step is rejected at build
     /// time.
     pub lag_comp: Option<LagCompConfig>,
+
+    /// Opt-in level-of-detail meshing for distant chunks. `None` (default)
+    /// builds no LOD meshes and ignores LOD requests — existing worlds are
+    /// unaffected. `Some(..)` builds a per-chunk pyramid of reduced-detail
+    /// meshes and serves them to clients requesting distant chunks as LOD
+    /// (see [`ChunkLodConfig`]). Validated against chunk dimensions at build
+    /// time.
+    pub chunk_lod: Option<ChunkLodConfig>,
 }
 
 impl Default for WorldConfig {
@@ -295,6 +304,7 @@ pub struct WorldConfigBuilder {
     peer_visible_radius: Option<f32>,
     fixed_timestep: Option<FixedStepConfig>,
     lag_comp: Option<LagCompConfig>,
+    chunk_lod: Option<ChunkLodConfig>,
 }
 
 impl WorldConfigBuilder {
@@ -345,6 +355,7 @@ impl WorldConfigBuilder {
             peer_visible_radius: None,
             fixed_timestep: None,
             lag_comp: None,
+            chunk_lod: None,
         }
     }
 
@@ -601,6 +612,15 @@ impl WorldConfigBuilder {
         self
     }
 
+    /// Opt into (or out of) level-of-detail meshing for distant chunks.
+    /// `None` (default) is today's behavior; `Some(..)` builds a per-chunk
+    /// LOD mesh pyramid and serves distant chunks as compact LOD meshes.
+    /// Validated against chunk dimensions at [`Self::build`].
+    pub fn chunk_lod(mut self, chunk_lod: Option<ChunkLodConfig>) -> Self {
+        self.chunk_lod = chunk_lod;
+        self
+    }
+
     /// Create a world configuration.
     pub fn build(self) -> WorldConfig {
         // Make sure there are still chunks in the world.
@@ -665,6 +685,12 @@ impl WorldConfigBuilder {
             }
         }
 
+        if let Some(chunk_lod) = &self.chunk_lod {
+            if let Err(error) = chunk_lod.validate(self.chunk_size, self.max_height) {
+                panic!("Invalid chunk_lod config: {}", error);
+            }
+        }
+
         WorldConfig {
             max_clients: self.max_clients,
             chunk_size: self.chunk_size,
@@ -724,6 +750,7 @@ impl WorldConfigBuilder {
             peer_visible_radius: self.peer_visible_radius,
             fixed_timestep: self.fixed_timestep,
             lag_comp: self.lag_comp,
+            chunk_lod: self.chunk_lod,
         }
     }
 }

--- a/server/world/generators/mesher.rs
+++ b/server/world/generators/mesher.rs
@@ -5,11 +5,28 @@ use hashbrown::{HashMap, HashSet};
 use rayon::{iter::IntoParallelIterator, prelude::ParallelIterator, ThreadPool, ThreadPoolBuilder};
 
 use crate::{
-    Chunk, GeometryProtocol, LightColor, MeshProtocol, MessageType, Registry, Space, Vec2, Vec3,
-    VoxelAccess, WorldConfig,
+    Chunk, ChunkLodConfig, GeometryProtocol, LightColor, MeshProtocol, MessageType, Registry,
+    Space, Vec2, Vec3, VoxelAccess, WorldConfig,
 };
 
 use super::lights::Lights;
+
+fn to_geometry_protocols(
+    geometries: Vec<voxelize_mesher::GeometryProtocol>,
+) -> Vec<GeometryProtocol> {
+    geometries
+        .into_iter()
+        .map(|g| GeometryProtocol {
+            voxel: g.voxel,
+            at: g.at.map(|[x, y, z]| vec![x, y, z]).unwrap_or_default(),
+            face_name: g.face_name,
+            positions: g.positions,
+            indices: g.indices,
+            uvs: g.uvs,
+            lights: g.lights,
+        })
+        .collect()
+}
 
 pub struct Mesher {
     pub(crate) queue: std::collections::VecDeque<Vec2<i32>>,
@@ -182,11 +199,20 @@ impl Mesher {
                     }
 
                     let started = std::time::Instant::now();
-                    if config.client_only_meshing {
-                        chunk.meshes = None;
-                    } else {
+                    let needs_full_meshes = !config.client_only_meshing;
+
+                    let mesher_registry = if needs_full_meshes || config.chunk_lod.is_some() {
                         let mut mesher_registry = registry.to_mesher_registry();
                         mesher_registry.build_cache();
+                        Some(mesher_registry)
+                    } else {
+                        None
+                    };
+
+                    if !needs_full_meshes {
+                        chunk.meshes = None;
+                    } else {
+                        let mesher_registry = mesher_registry.as_ref().unwrap();
 
                         for level in sub_chunks {
                             let level = level as i32;
@@ -202,33 +228,69 @@ impl Mesher {
                                 &min_arr,
                                 &max_arr,
                                 &space,
-                                &mesher_registry,
+                                mesher_registry,
                             );
 
-                            let geometries: Vec<GeometryProtocol> = mesher_geometries
-                                .into_iter()
-                                .map(|g| GeometryProtocol {
-                                    voxel: g.voxel,
-                                    at: g.at.map(|[x, y, z]| vec![x, y, z]).unwrap_or_default(),
-                                    face_name: g.face_name,
-                                    positions: g.positions,
-                                    indices: g.indices,
-                                    uvs: g.uvs,
-                                    lights: g.lights,
-                                })
-                                .collect();
-
-                            chunk
-                                .meshes
-                                .get_or_insert_with(HashMap::new)
-                                .insert(level as u32, MeshProtocol { level, geometries });
+                            chunk.meshes.get_or_insert_with(HashMap::new).insert(
+                                level as u32,
+                                MeshProtocol {
+                                    level,
+                                    lod: 0,
+                                    geometries: to_geometry_protocols(mesher_geometries),
+                                },
+                            );
                         }
+                    }
+
+                    if let Some(chunk_lod) = &config.chunk_lod {
+                        Self::build_lod_pyramid(
+                            &mut chunk,
+                            chunk_lod,
+                            mesher_registry.as_ref().unwrap(),
+                            &config,
+                        );
                     }
                     super::gen_profiler::record("mesh: greedy", started.elapsed());
 
                     let _ = sender.send((chunk, r#type.clone()));
                 });
         });
+    }
+
+    /// Build (or rebuild) the chunk's reduced-detail mesh pyramid, one
+    /// whole-column mesh per configured LOD level. Runs on the meshing
+    /// thread pool next to the full-detail meshing; the downsample pass is a
+    /// single sweep over the chunk arrays and the coarse mesh volume is
+    /// `1/8^level` of the chunk, so the added cost is a small fraction of a
+    /// full mesh.
+    fn build_lod_pyramid(
+        chunk: &mut Chunk,
+        chunk_lod: &ChunkLodConfig,
+        mesher_registry: &voxelize_mesher::Registry,
+        config: &WorldConfig,
+    ) {
+        let shape = [config.chunk_size, config.max_height, config.chunk_size];
+
+        let lod_meshes = chunk.lod_meshes.get_or_insert_with(HashMap::new);
+
+        for level in chunk_lod.levels() {
+            let geometries = voxelize_mesher::mesh_chunk_lod(
+                &chunk.voxels.data,
+                &chunk.lights.data,
+                shape,
+                level,
+                mesher_registry,
+            );
+
+            lod_meshes.insert(
+                level,
+                MeshProtocol {
+                    level: 0,
+                    lod: level,
+                    geometries: to_geometry_protocols(geometries),
+                },
+            );
+        }
     }
 
     pub fn results(&mut self) -> Vec<(Chunk, MessageType)> {

--- a/server/world/interests.rs
+++ b/server/world/interests.rs
@@ -8,6 +8,13 @@ use crate::Vec2;
 pub struct ChunkInterests {
     pub map: HashMap<Vec2<i32>, HashSet<String>>,
     pub weights: HashMap<Vec2<i32>, f32>,
+
+    /// Which clients want a chunk as a reduced-detail mesh, and at which LOD
+    /// level. A client in `map` but absent here wants the full chunk (data
+    /// and/or full meshes); a client present here receives only the compact
+    /// LOD mesh for that chunk. Kept consistent with `map`: removing a
+    /// client's interest also clears its LOD level.
+    pub lod_levels: HashMap<Vec2<i32>, HashMap<String, u32>>,
 }
 
 impl ChunkInterests {
@@ -76,6 +83,37 @@ impl ChunkInterests {
         let mut clients = self.map.remove(coords).unwrap_or_default();
         clients.insert(client_id.to_owned());
         self.map.insert(coords.to_owned(), clients);
+        self.clear_lod(client_id, coords);
+    }
+
+    /// Register interest in a chunk as a reduced-detail mesh at `level`.
+    /// Supersedes any full-form interest the client held for the chunk.
+    pub fn add_lod(&mut self, client_id: &str, coords: &Vec2<i32>, level: u32) {
+        let mut clients = self.map.remove(coords).unwrap_or_default();
+        clients.insert(client_id.to_owned());
+        self.map.insert(coords.to_owned(), clients);
+
+        self.lod_levels
+            .entry(coords.to_owned())
+            .or_default()
+            .insert(client_id.to_owned(), level);
+    }
+
+    /// The LOD level a client wants a chunk at, or `None` for the full form.
+    pub fn get_lod(&self, client_id: &str, coords: &Vec2<i32>) -> Option<u32> {
+        self.lod_levels
+            .get(coords)
+            .and_then(|levels| levels.get(client_id))
+            .copied()
+    }
+
+    fn clear_lod(&mut self, client_id: &str, coords: &Vec2<i32>) {
+        if let Some(levels) = self.lod_levels.get_mut(coords) {
+            levels.remove(client_id);
+            if levels.is_empty() {
+                self.lod_levels.remove(coords);
+            }
+        }
     }
 
     pub fn remove(&mut self, client_id: &str, coords: &Vec2<i32>) {
@@ -86,6 +124,8 @@ impl ChunkInterests {
                 self.map.remove(coords);
             }
         }
+
+        self.clear_lod(client_id, coords);
     }
 
     pub fn add_many(&mut self, client_id: &str, coords: &[Vec2<i32>]) {
@@ -105,5 +145,75 @@ impl ChunkInterests {
             clients.remove(client_id);
             !clients.is_empty()
         });
+        self.lod_levels.retain(|_, levels| {
+            levels.remove(client_id);
+            !levels.is_empty()
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lod_interest_is_tracked_per_client_and_level() {
+        let mut interests = ChunkInterests::new();
+        let coords = Vec2(3, -2);
+
+        interests.add_lod("a", &coords, 1);
+        interests.add_lod("b", &coords, 2);
+
+        assert!(interests.is_interested("a", &coords));
+        assert_eq!(interests.get_lod("a", &coords), Some(1));
+        assert_eq!(interests.get_lod("b", &coords), Some(2));
+    }
+
+    #[test]
+    fn full_interest_supersedes_lod_interest() {
+        let mut interests = ChunkInterests::new();
+        let coords = Vec2(0, 0);
+
+        interests.add_lod("a", &coords, 2);
+        interests.add("a", &coords);
+
+        assert!(interests.is_interested("a", &coords));
+        assert_eq!(interests.get_lod("a", &coords), None);
+    }
+
+    #[test]
+    fn lod_interest_supersedes_full_interest() {
+        let mut interests = ChunkInterests::new();
+        let coords = Vec2(0, 0);
+
+        interests.add("a", &coords);
+        interests.add_lod("a", &coords, 3);
+
+        assert_eq!(interests.get_lod("a", &coords), Some(3));
+    }
+
+    #[test]
+    fn removal_clears_both_forms() {
+        let mut interests = ChunkInterests::new();
+        let coords = Vec2(1, 1);
+
+        interests.add_lod("a", &coords, 1);
+        interests.remove("a", &coords);
+
+        assert!(!interests.has_interests(&coords));
+        assert_eq!(interests.get_lod("a", &coords), None);
+        assert!(interests.lod_levels.is_empty());
+    }
+
+    #[test]
+    fn remove_client_clears_lod_levels() {
+        let mut interests = ChunkInterests::new();
+
+        interests.add_lod("a", &Vec2(0, 0), 1);
+        interests.add_lod("b", &Vec2(0, 0), 2);
+        interests.remove_client("a");
+
+        assert_eq!(interests.get_lod("a", &Vec2(0, 0)), None);
+        assert_eq!(interests.get_lod("b", &Vec2(0, 0)), Some(2));
     }
 }

--- a/server/world/mod.rs
+++ b/server/world/mod.rs
@@ -3047,6 +3047,102 @@ mod chunk_lod_wiring_tests {
         });
     }
 
+    // The sending system routes by interest form: LOD-interested clients get
+    // only the compact LOD model (no voxel or light data), full-interest
+    // clients get chunk data exactly as before.
+    #[test]
+    fn sending_system_routes_lod_and_full_forms_by_interest() {
+        use specs::RunNow;
+
+        actix::System::new().block_on(async {
+            let config = WorldConfig::new()
+                .min_chunk([-3, -3])
+                .max_chunk([3, 3])
+                .max_height(64)
+                .sub_chunks(4)
+                .chunk_lod(Some(ChunkLodConfig { max_level: 2 }))
+                .build();
+            let mut world = World::new("lod-sending", &config);
+            let mut registry = Registry::new();
+            registry.register_block(&Block::new("Stone").id(1).build());
+            world.ecs_mut().insert(registry);
+            world
+                .pipeline_mut()
+                .add_stage(FlatlandStage::new().add_soiling(1, 10));
+
+            let coords = Vec2(0, 0);
+            let mut requests = ChunkRequestsComp::new();
+            requests.add_lod(&coords, 1);
+            world
+                .ecs_mut()
+                .create_entity()
+                .with(IDComp::new("lod-client"))
+                .with(requests)
+                .build();
+
+            let deadline = StdInstant::now() + StdDuration::from_secs(20);
+            while !world.chunks().is_chunk_ready(&coords) {
+                world.tick();
+                assert!(StdInstant::now() < deadline, "chunk never became ready");
+                std::thread::sleep(StdDuration::from_millis(5));
+            }
+
+            {
+                let mut interests = world.chunk_interest_mut();
+                interests.add_lod("lod-client", &coords, 1);
+                interests.add("full-client", &coords);
+            }
+            // Drain whatever the tick loop already queued, then trigger one
+            // clean send of the ready chunk.
+            world.write_resource::<MessageQueues>().drain_prioritized();
+            world
+                .chunks_mut()
+                .add_chunk_to_send(&coords, &MessageType::Load, false);
+
+            ChunkSendingSystem::new().run_now(world.ecs());
+
+            let queued = world
+                .write_resource::<MessageQueues>()
+                .drain_prioritized();
+
+            let mut lod_payloads = 0;
+            let mut full_payloads = 0;
+
+            for (message, filter) in queued {
+                let client_id = match &filter {
+                    ClientFilter::Direct(id) => id.clone(),
+                    other => panic!("unexpected filter {:?}", other),
+                };
+
+                for chunk in &message.chunks {
+                    if client_id == "lod-client" {
+                        lod_payloads += 1;
+                        assert_eq!(chunk.meshes.len(), 1);
+                        assert_eq!(chunk.meshes[0].lod, 1);
+                        assert!(
+                            chunk.voxels.is_empty() && chunk.lights.is_empty(),
+                            "LOD clients must not receive chunk data"
+                        );
+                    } else {
+                        assert_eq!(client_id, "full-client");
+                        full_payloads += 1;
+                        assert!(
+                            !chunk.voxels.is_empty(),
+                            "full clients keep receiving chunk data"
+                        );
+                        assert!(
+                            chunk.meshes.is_empty(),
+                            "client_only_meshing worlds send no full meshes"
+                        );
+                    }
+                }
+            }
+
+            assert_eq!(lod_payloads, 1, "LOD client gets exactly one LOD model");
+            assert_eq!(full_payloads, 1, "full client gets exactly one data model");
+        });
+    }
+
     // Worlds that never opt in ignore LOD requests wholesale — a client
     // cannot switch LOD serving on by itself — and levels outside the
     // configured pyramid are discarded.

--- a/server/world/mod.rs
+++ b/server/world/mod.rs
@@ -5,6 +5,7 @@ mod config;
 pub mod cpu_profiler;
 mod entities;
 mod entity_ids;
+mod chunk_lod;
 mod events;
 mod fixed_step;
 mod generators;
@@ -63,6 +64,7 @@ use crate::{
 use super::common::ClientFilter;
 
 pub use bookkeeping::*;
+pub use chunk_lod::*;
 pub use clients::*;
 pub use components::*;
 pub use config::*;
@@ -672,6 +674,28 @@ struct OnLoadRequest {
     center: Vec2<i32>,
     direction: Vec2<f32>,
     chunks: Vec<Vec2<i32>>,
+    /// Chunks requested as reduced-detail meshes: `[x, z, lodLevel]` per
+    /// entry. Only sent by clients of worlds that enable `chunk_lod`; absent
+    /// (and ignored) otherwise.
+    #[serde(default, rename = "lodChunks")]
+    lod_chunks: Vec<(i32, i32, u32)>,
+}
+
+/// Gate inbound LOD chunk requests on the world's opt-in: worlds without
+/// `chunk_lod` drop them wholesale (a client cannot switch LOD serving on by
+/// itself), and levels outside the configured pyramid are discarded.
+fn filter_lod_requests(
+    chunk_lod: Option<&ChunkLodConfig>,
+    lod_chunks: Vec<(i32, i32, u32)>,
+) -> Vec<(Vec2<i32>, u32)> {
+    match chunk_lod {
+        Some(config) => lod_chunks
+            .into_iter()
+            .filter(|(_, _, level)| *level >= 1 && *level <= config.max_level)
+            .map(|(x, z, level)| (Vec2(x, z), level))
+            .collect(),
+        None => Vec::new(),
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -2360,7 +2384,10 @@ impl World {
         };
 
         let chunks = json.chunks;
-        if chunks.is_empty() {
+        let lod_chunks =
+            filter_lod_requests(self.config().chunk_lod.as_ref(), json.lod_chunks);
+
+        if chunks.is_empty() && lod_chunks.is_empty() {
             return;
         }
 
@@ -2371,6 +2398,10 @@ impl World {
             if let Some(requests) = storage.get_mut(client_ent) {
                 chunks.iter().for_each(|coords| {
                     requests.add(coords);
+                });
+
+                lod_chunks.iter().for_each(|(coords, level)| {
+                    requests.add_lod(coords, *level);
                 });
 
                 requests.set_center(&json.center);
@@ -2912,5 +2943,128 @@ mod lag_comp_wiring_tests {
             world.record_rewind_poses(1);
             assert!(world.rewound_pose(entity.id() as u64, 1).is_none());
         });
+    }
+}
+
+#[cfg(test)]
+mod chunk_lod_wiring_tests {
+    use super::*;
+    use crate::{ChunkLodConfig, FlatlandStage};
+    use std::time::{Duration as StdDuration, Instant as StdInstant};
+
+    // The LOAD request json accepts the optional camelCase `lodChunks` list
+    // new clients send; absent (legacy clients), it defaults empty.
+    #[test]
+    fn on_load_request_parses_lod_chunks() {
+        let json = r#"{
+            "center": [0, 0],
+            "direction": [0.0, 1.0],
+            "chunks": [[1, 2]],
+            "lodChunks": [[8, -3, 1], [16, 0, 2]]
+        }"#;
+        let request: OnLoadRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.chunks, vec![Vec2(1, 2)]);
+        assert_eq!(request.lod_chunks, vec![(8, -3, 1), (16, 0, 2)]);
+
+        let legacy = r#"{"center": [0, 0], "direction": [0.0, 1.0], "chunks": []}"#;
+        let request: OnLoadRequest = serde_json::from_str(legacy).unwrap();
+        assert!(request.lod_chunks.is_empty());
+    }
+
+    // End-to-end through the real dispatcher: a LOD request on an opted-in
+    // world schedules generation, the mesher builds the pyramid, and the
+    // client's LOD interest is registered at the requested level so the
+    // sending system will serve LOD models for this chunk from now on.
+    #[test]
+    fn lod_request_generates_chunk_and_registers_lod_interest() {
+        actix::System::new().block_on(async {
+            let config = WorldConfig::new()
+                .min_chunk([-3, -3])
+                .max_chunk([3, 3])
+                .max_height(64)
+                .sub_chunks(4)
+                .chunk_lod(Some(ChunkLodConfig { max_level: 2 }))
+                .build();
+            let mut world = World::new("lod-wiring", &config);
+            let mut registry = Registry::new();
+            registry.register_block(&Block::new("Stone").id(1).build());
+            world.ecs_mut().insert(registry);
+            world
+                .pipeline_mut()
+                .add_stage(FlatlandStage::new().add_soiling(1, 10));
+
+            let coords = Vec2(0, 0);
+            let mut requests = ChunkRequestsComp::new();
+            requests.add_lod(&coords, 2);
+            world
+                .ecs_mut()
+                .create_entity()
+                .with(IDComp::new("lod-client"))
+                .with(requests)
+                .build();
+
+            let deadline = StdInstant::now() + StdDuration::from_secs(20);
+            loop {
+                world.tick();
+
+                let ready_with_lod = world
+                    .chunks()
+                    .raw(&coords)
+                    .map(|chunk| {
+                        chunk.status == ChunkStatus::Ready
+                            && chunk
+                                .lod_meshes
+                                .as_ref()
+                                .map_or(false, |meshes| meshes.contains_key(&2))
+                    })
+                    .unwrap_or(false);
+
+                if ready_with_lod {
+                    break;
+                }
+
+                assert!(
+                    StdInstant::now() < deadline,
+                    "chunk never became ready with a LOD pyramid"
+                );
+                std::thread::sleep(StdDuration::from_millis(5));
+            }
+
+            assert_eq!(
+                world.chunk_interest().get_lod("lod-client", &coords),
+                Some(2),
+                "LOD interest must be registered at the requested level"
+            );
+
+            let chunks = world.chunks();
+            let chunk = chunks.raw(&coords).unwrap();
+            let model = chunk.to_lod_model(2).expect("LOD model must resolve");
+            assert_eq!(model.meshes[0].lod, 2);
+            assert!(
+                !model.meshes[0].geometries.is_empty(),
+                "flatland terrain must produce LOD geometry"
+            );
+        });
+    }
+
+    // Worlds that never opt in ignore LOD requests wholesale — a client
+    // cannot switch LOD serving on by itself — and levels outside the
+    // configured pyramid are discarded.
+    #[test]
+    fn lod_requests_are_gated_on_world_opt_in() {
+        let requested = vec![(0, 0, 1), (8, 8, 2), (16, 0, 3), (24, 0, 0)];
+
+        assert!(
+            filter_lod_requests(None, requested.clone()).is_empty(),
+            "worlds without chunk_lod must drop every LOD request"
+        );
+
+        let config = ChunkLodConfig { max_level: 2 };
+        let accepted = filter_lod_requests(Some(&config), requested);
+        assert_eq!(
+            accepted,
+            vec![(Vec2(0, 0), 1), (Vec2(8, 8), 2)],
+            "levels outside 1..=max_level must be discarded"
+        );
     }
 }

--- a/server/world/systems/chunk/requests.rs
+++ b/server/world/systems/chunk/requests.rs
@@ -27,39 +27,94 @@ impl<'a> System<'a> for ChunkRequestsSystem {
         let max_response_per_tick = config.max_response_per_tick;
 
         let mut to_send: HashMap<String, HashSet<Vec2<i32>>> = HashMap::new();
+        let mut to_send_lod: HashMap<String, Vec<(Vec2<i32>, u32)>> = HashMap::new();
+        let mut send_counts: HashMap<String, usize> = HashMap::new();
+
+        // Queue a chunk's generation/meshing work if nobody was interested in
+        // it yet, mirroring the not-ready branch of full-detail requests.
+        let mut schedule_chunk = |coords: &Vec2<i32>,
+                                  interests: &ChunkInterests,
+                                  pipeline: &mut Pipeline,
+                                  mesher: &mut Mesher| {
+            if !interests.has_interests(coords) {
+                for coords in chunks.light_traversed_chunks(coords) {
+                    match chunks.raw(&coords) {
+                        Some(chunk) if matches!(chunk.status, ChunkStatus::Meshing) => {
+                            mesher.add_chunk(&coords, false);
+                        }
+                        None | Some(_) => {
+                            pipeline.add_chunk(&coords, false);
+                        }
+                    }
+                }
+            }
+        };
 
         for (id, requests) in (&ids, &mut requests).join() {
             let mut to_add_back_to_requested = HashSet::new();
 
             for coords in requests.requests.drain(..) {
                 if chunks.is_chunk_ready(&coords) {
-                    let clients_to_send = to_send.entry(id.0.clone()).or_default();
+                    let count = send_counts.entry(id.0.clone()).or_default();
 
-                    if clients_to_send.len() >= max_response_per_tick {
+                    if *count >= max_response_per_tick {
                         to_add_back_to_requested.insert(coords);
                         continue;
                     }
 
-                    clients_to_send.insert(coords.clone());
+                    *count += 1;
+                    to_send.entry(id.0.clone()).or_default().insert(coords.clone());
                     interests.add(&id.0, &coords);
                 } else {
-                    if !interests.has_interests(&coords) {
-                        for coords in chunks.light_traversed_chunks(&coords) {
-                            match chunks.raw(&coords) {
-                                Some(chunk) if matches!(chunk.status, ChunkStatus::Meshing) => {
-                                    mesher.add_chunk(&coords, false);
-                                }
-                                None | Some(_) => {
-                                    pipeline.add_chunk(&coords, false);
-                                }
-                            }
-                        }
-                    }
+                    schedule_chunk(&coords, &interests, &mut pipeline, &mut mesher);
                     interests.add(&id.0, &coords);
                 }
             }
 
             requests.requests.extend(to_add_back_to_requested);
+
+            let mut to_add_back_to_lod = Vec::new();
+
+            for (coords, level) in requests.lod_requests.drain(..) {
+                let has_lod_mesh = chunks
+                    .raw(&coords)
+                    .map(|chunk| {
+                        chunk.status == ChunkStatus::Ready
+                            && chunk
+                                .lod_meshes
+                                .as_ref()
+                                .map_or(false, |meshes| meshes.contains_key(&level))
+                    })
+                    .unwrap_or(false);
+
+                if has_lod_mesh {
+                    let count = send_counts.entry(id.0.clone()).or_default();
+
+                    if *count >= max_response_per_tick {
+                        to_add_back_to_lod.push((coords, level));
+                        continue;
+                    }
+
+                    *count += 1;
+                    to_send_lod
+                        .entry(id.0.clone())
+                        .or_default()
+                        .push((coords.clone(), level));
+                    interests.add_lod(&id.0, &coords, level);
+                } else {
+                    if chunks.is_chunk_ready(&coords) {
+                        // Ready but the pyramid level is missing (e.g. chunk
+                        // meshed before a restart that changed the config):
+                        // remesh so the send path can self-heal.
+                        mesher.add_chunk(&coords, false);
+                    } else {
+                        schedule_chunk(&coords, &interests, &mut pipeline, &mut mesher);
+                    }
+                    interests.add_lod(&id.0, &coords, level);
+                }
+            }
+
+            requests.lod_requests.extend(to_add_back_to_lod);
         }
 
         for (id, coords) in to_send {
@@ -72,6 +127,24 @@ impl<'a> System<'a> for ChunkRequestsSystem {
                     })
                 })
                 .collect();
+
+            let message = Message::new(&MessageType::Load).chunks(&chunks).build();
+            queue.push((message, ClientFilter::Direct(id)));
+        }
+
+        for (id, coords_levels) in to_send_lod {
+            let chunks: Vec<ChunkProtocol> = coords_levels
+                .into_iter()
+                .filter_map(|(coords, level)| {
+                    chunks
+                        .get(&coords)
+                        .and_then(|chunk| chunk.to_lod_model(level))
+                })
+                .collect();
+
+            if chunks.is_empty() {
+                continue;
+            }
 
             let message = Message::new(&MessageType::Load).chunks(&chunks).build();
             queue.push((message, ClientFilter::Direct(id)));

--- a/server/world/systems/chunk/sending.rs
+++ b/server/world/systems/chunk/sending.rs
@@ -38,6 +38,8 @@ impl<'a> System<'a> for ChunkSendingSystem {
         let mut client_load_data: HashMap<String, Vec<ChunkProtocol>> = HashMap::new();
         let mut client_update_mesh: HashMap<String, Vec<ChunkProtocol>> = HashMap::new();
         let mut client_update_data: HashMap<String, Vec<ChunkProtocol>> = HashMap::new();
+        let mut client_load_lod: HashMap<String, Vec<ChunkProtocol>> = HashMap::new();
+        let mut client_update_lod: HashMap<String, Vec<ChunkProtocol>> = HashMap::new();
 
         while let Some((coords, msg_type)) = to_send.pop_front() {
             let chunk = match chunks.get_mut(&coords) {
@@ -54,34 +56,68 @@ impl<'a> System<'a> for ChunkSendingSystem {
                 continue;
             }
 
+            // Clients interested in the chunk as a reduced-detail mesh get
+            // only the compact LOD model for their level — never voxel or
+            // light data — on both the load and the update path.
+            let mut full_clients: Vec<&String> = Vec::with_capacity(interested_clients.len());
+            {
+                let lod_bucket = if msg_type == MessageType::Load {
+                    &mut client_load_lod
+                } else {
+                    &mut client_update_lod
+                };
+
+                for client_id in &interested_clients {
+                    match interests.get_lod(client_id, &coords) {
+                        Some(level) => {
+                            if let Some(lod_model) = chunk.to_lod_model(level) {
+                                lod_bucket
+                                    .entry(client_id.clone())
+                                    .or_default()
+                                    .push(lod_model);
+                            }
+                        }
+                        None => full_clients.push(client_id),
+                    }
+                }
+            }
+
             if msg_type == MessageType::Load {
+                if full_clients.is_empty() {
+                    continue;
+                }
+
                 let mesh_model = chunk.to_model(true, false, 0..(config.sub_chunks as u32));
                 let data_model = chunk.to_model(false, true, 0..(config.sub_chunks as u32));
 
-                for client_id in &interested_clients {
+                for client_id in &full_clients {
                     if !config.client_only_meshing {
                         client_load_mesh
-                            .entry(client_id.clone())
+                            .entry((*client_id).clone())
                             .or_default()
                             .push(mesh_model.clone());
                     }
                     client_load_data
-                        .entry(client_id.clone())
+                        .entry((*client_id).clone())
                         .or_default()
                         .push(data_model.clone());
                 }
             } else {
                 let updated_levels: Vec<u32> = chunk.updated_levels.drain().collect();
 
+                if full_clients.is_empty() {
+                    continue;
+                }
+
                 if !updated_levels.is_empty() {
                     let min_level = *updated_levels.iter().min().unwrap();
                     let max_level = *updated_levels.iter().max().unwrap();
                     let mesh_model = chunk.to_model(true, false, min_level..(max_level + 1));
 
-                    for client_id in &interested_clients {
+                    for client_id in &full_clients {
                         if !config.client_only_meshing {
                             client_update_mesh
-                                .entry(client_id.clone())
+                                .entry((*client_id).clone())
                                 .or_default()
                                 .push(mesh_model.clone());
                         }
@@ -89,57 +125,31 @@ impl<'a> System<'a> for ChunkSendingSystem {
                 }
 
                 let data_model = chunk.to_model(false, true, 0..0);
-                for client_id in &interested_clients {
+                for client_id in &full_clients {
                     client_update_data
-                        .entry(client_id.clone())
+                        .entry((*client_id).clone())
                         .or_default()
                         .push(data_model.clone());
                 }
             }
         }
 
-        for (client_id, chunk_models) in client_load_mesh {
-            if !chunk_models.is_empty() {
-                queue.push((
-                    Message::new(&MessageType::Load)
-                        .chunks(&chunk_models)
-                        .build(),
-                    ClientFilter::Direct(client_id),
-                ));
+        let mut flush = |batches: HashMap<String, Vec<ChunkProtocol>>, msg_type: &MessageType| {
+            for (client_id, chunk_models) in batches {
+                if !chunk_models.is_empty() {
+                    queue.push((
+                        Message::new(msg_type).chunks(&chunk_models).build(),
+                        ClientFilter::Direct(client_id),
+                    ));
+                }
             }
-        }
+        };
 
-        for (client_id, chunk_models) in client_load_data {
-            if !chunk_models.is_empty() {
-                queue.push((
-                    Message::new(&MessageType::Load)
-                        .chunks(&chunk_models)
-                        .build(),
-                    ClientFilter::Direct(client_id),
-                ));
-            }
-        }
-
-        for (client_id, chunk_models) in client_update_mesh {
-            if !chunk_models.is_empty() {
-                queue.push((
-                    Message::new(&MessageType::Update)
-                        .chunks(&chunk_models)
-                        .build(),
-                    ClientFilter::Direct(client_id),
-                ));
-            }
-        }
-
-        for (client_id, chunk_models) in client_update_data {
-            if !chunk_models.is_empty() {
-                queue.push((
-                    Message::new(&MessageType::Update)
-                        .chunks(&chunk_models)
-                        .build(),
-                    ClientFilter::Direct(client_id),
-                ));
-            }
-        }
+        flush(client_load_mesh, &MessageType::Load);
+        flush(client_load_data, &MessageType::Load);
+        flush(client_load_lod, &MessageType::Load);
+        flush(client_update_mesh, &MessageType::Update);
+        flush(client_update_data, &MessageType::Update);
+        flush(client_update_lod, &MessageType::Update);
     }
 }

--- a/server/world/voxels/chunk.rs
+++ b/server/world/voxels/chunk.rs
@@ -43,6 +43,11 @@ pub struct Chunk {
 
     pub meshes: Option<HashMap<u32, MeshProtocol>>,
 
+    /// Reduced-detail whole-column meshes keyed by LOD level (`1..=max`),
+    /// built by the mesher when the world opts into `chunk_lod`. `None` when
+    /// the feature is off.
+    pub lod_meshes: Option<HashMap<u32, MeshProtocol>>,
+
     pub min: Vec3<i32>,
     pub max: Vec3<i32>,
 
@@ -155,6 +160,22 @@ impl Chunk {
                 None
             },
         }
+    }
+
+    /// Convert chunk to a LOD-only protocol model: just the reduced-detail
+    /// mesh at `level`, no voxel or light data. Returns `None` when the mesh
+    /// for that level has not been built (feature off or not yet meshed).
+    pub fn to_lod_model(&self, level: u32) -> Option<ChunkProtocol> {
+        let mesh = self.lod_meshes.as_ref()?.get(&level)?;
+
+        Some(ChunkProtocol {
+            x: self.coords.0,
+            z: self.coords.1,
+            id: self.id.clone(),
+            meshes: vec![mesh.to_owned()],
+            voxels: None,
+            lights: None,
+        })
     }
 
     /// Flag a level of sub-chunk as dirty, waiting to be remeshed.

--- a/tests/chunk_lod_tests.rs
+++ b/tests/chunk_lod_tests.rs
@@ -1,0 +1,292 @@
+//! Integration tests for opt-in LOD chunk meshing: the mesher-built pyramid,
+//! the LOD chunk protocol model, and — critically — the wire round-trip of
+//! the new `Mesh.lod` field through the real prost encode/decode path.
+
+use std::time::{Duration, Instant};
+
+use voxelize::{
+    decode_message, encode_message, Block, Chunk, ChunkLodConfig, ChunkOptions, Chunks,
+    GeometryProtocol, MeshProtocol, Mesher, Message, MessageType, Registry, Vec2, VoxelAccess,
+    WorldConfig,
+};
+
+const STONE: u32 = 1;
+const GRASS: u32 = 2;
+
+const CHUNK_SIZE: usize = 16;
+const MAX_HEIGHT: usize = 64;
+
+fn create_registry() -> Registry {
+    let mut registry = Registry::new();
+    registry.register_block(&Block::new("Stone").id(STONE).build());
+    registry.register_block(&Block::new("Grass Block").id(GRASS).build());
+    registry
+}
+
+fn create_config(chunk_lod: Option<ChunkLodConfig>, client_only_meshing: bool) -> WorldConfig {
+    WorldConfig {
+        chunk_size: CHUNK_SIZE,
+        max_height: MAX_HEIGHT,
+        max_light_level: 15,
+        sub_chunks: 4,
+        min_chunk: [0, 0],
+        max_chunk: [0, 0],
+        client_only_meshing,
+        chunk_lod,
+        ..Default::default()
+    }
+}
+
+/// Build a single ready chunk with hilly terrain and run it through the real
+/// `Mesher::process` thread pool, returning the meshed chunk.
+fn mesh_terrain_chunk(config: &WorldConfig, registry: &Registry) -> Chunk {
+    let mut chunks = Chunks::new(config);
+
+    let mut chunk = Chunk::new(
+        "lod-test",
+        0,
+        0,
+        &ChunkOptions {
+            size: config.chunk_size,
+            max_height: config.max_height,
+            sub_chunks: config.sub_chunks,
+        },
+    );
+
+    for x in 0..CHUNK_SIZE as i32 {
+        for z in 0..CHUNK_SIZE as i32 {
+            let height = 6 + ((x * 7 + z * 13) % 9);
+            for y in 0..height {
+                chunk.set_voxel(x, y, z, STONE);
+            }
+            chunk.set_voxel(x, height, z, GRASS);
+        }
+    }
+
+    chunk.calculate_max_height(registry);
+    chunks.renew(chunk.clone(), false);
+
+    let space = chunks
+        .make_space(&Vec2(0, 0), config.max_light_level as usize)
+        .needs_height_maps()
+        .needs_voxels()
+        .needs_lights()
+        .build();
+
+    let mut mesher = Mesher::new();
+    mesher.add_chunk(&Vec2(0, 0), false);
+    mesher.process(
+        vec![(chunk, space)],
+        &MessageType::Load,
+        registry,
+        config,
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some((chunk, _)) = mesher.results().into_iter().next() {
+            return chunk;
+        }
+        assert!(Instant::now() < deadline, "mesher did not produce a result");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn mesher_builds_lod_pyramid_when_enabled() {
+    let registry = create_registry();
+    let config = create_config(Some(ChunkLodConfig { max_level: 2 }), true);
+
+    let chunk = mesh_terrain_chunk(&config, &registry);
+
+    assert!(
+        chunk.meshes.is_none(),
+        "client_only_meshing worlds still skip full meshes"
+    );
+
+    let lod_meshes = chunk
+        .lod_meshes
+        .as_ref()
+        .expect("LOD pyramid must be built when chunk_lod is enabled");
+
+    for level in 1..=2u32 {
+        let mesh = lod_meshes
+            .get(&level)
+            .unwrap_or_else(|| panic!("missing LOD level {level}"));
+        assert_eq!(mesh.lod, level);
+        assert_eq!(mesh.level, 0, "LOD meshes span the whole column");
+        assert!(
+            !mesh.geometries.is_empty(),
+            "terrain chunk must produce LOD geometry at level {level}"
+        );
+
+        for geometry in &mesh.geometries {
+            for (index, value) in geometry.positions.iter().enumerate() {
+                let axis_max = if index % 3 == 1 {
+                    MAX_HEIGHT as f32
+                } else {
+                    CHUNK_SIZE as f32
+                };
+                assert!(
+                    *value >= 0.0 && *value <= axis_max,
+                    "LOD geometry must stay within chunk bounds in block units, \
+                     got {value} on axis {}",
+                    index % 3
+                );
+            }
+        }
+    }
+
+    // Higher LOD levels must not have more geometry than lower ones.
+    let vertex_count = |mesh: &MeshProtocol| -> usize {
+        mesh.geometries
+            .iter()
+            .map(|geometry| geometry.positions.len())
+            .sum()
+    };
+    assert!(
+        vertex_count(&lod_meshes[&2]) <= vertex_count(&lod_meshes[&1]),
+        "coarser LOD must not increase vertex count"
+    );
+}
+
+#[test]
+fn mesher_builds_no_pyramid_when_disabled() {
+    let registry = create_registry();
+    let config = create_config(None, true);
+
+    let chunk = mesh_terrain_chunk(&config, &registry);
+
+    assert!(
+        chunk.lod_meshes.is_none(),
+        "worlds without chunk_lod must not pay for LOD meshing"
+    );
+}
+
+#[test]
+fn lod_pyramid_coexists_with_server_side_meshing() {
+    let registry = create_registry();
+    let config = create_config(Some(ChunkLodConfig { max_level: 1 }), false);
+
+    let chunk = mesh_terrain_chunk(&config, &registry);
+
+    let meshes = chunk.meshes.as_ref().expect("full meshes still built");
+    assert!(!meshes.is_empty());
+    assert!(meshes.values().all(|mesh| mesh.lod == 0));
+
+    let lod_meshes = chunk.lod_meshes.as_ref().expect("pyramid built");
+    assert!(lod_meshes.contains_key(&1));
+}
+
+#[test]
+fn to_lod_model_is_mesh_only() {
+    let registry = create_registry();
+    let config = create_config(Some(ChunkLodConfig { max_level: 2 }), true);
+
+    let chunk = mesh_terrain_chunk(&config, &registry);
+
+    let model = chunk.to_lod_model(1).expect("LOD level 1 model");
+    assert_eq!(model.meshes.len(), 1);
+    assert_eq!(model.meshes[0].lod, 1);
+    assert!(
+        model.voxels.is_none() && model.lights.is_none(),
+        "LOD models must not carry chunk data"
+    );
+
+    assert!(
+        chunk.to_lod_model(3).is_none(),
+        "levels beyond the configured pyramid must not resolve"
+    );
+}
+
+/// The regression this feature must never reintroduce: a protocol field that
+/// exists in Rust but is dropped on the wire. Encode a LOAD message holding a
+/// LOD mesh through the real prost path and decode it back.
+#[test]
+fn mesh_lod_field_survives_wire_roundtrip() {
+    let registry = create_registry();
+    let config = create_config(Some(ChunkLodConfig { max_level: 2 }), true);
+
+    let chunk = mesh_terrain_chunk(&config, &registry);
+    let model = chunk.to_lod_model(2).expect("LOD level 2 model");
+    let sent_geometry_count = model.meshes[0].geometries.len();
+
+    let message = Message::new(&MessageType::Load).chunks(&[model]).build();
+    let encoded = encode_message(&message);
+
+    // Large chunk messages pass through LZ4 frame compression; make sure the
+    // test exercises the same framing the client sees.
+    let decoded = if encoded.len() > 4096 {
+        let mut decompressed = Vec::new();
+        let mut decoder = lz4_flex::frame::FrameDecoder::new(&encoded[..]);
+        std::io::Read::read_to_end(&mut decoder, &mut decompressed).unwrap();
+        decode_message(&decompressed).unwrap()
+    } else {
+        decode_message(&encoded).unwrap()
+    };
+
+    assert_eq!(decoded.chunks.len(), 1);
+    let mesh = &decoded.chunks[0].meshes[0];
+    assert_eq!(mesh.lod, 2, "Mesh.lod must survive encode/decode");
+    assert_eq!(mesh.level, 0);
+    assert_eq!(mesh.geometries.len(), sent_geometry_count);
+    assert!(decoded.chunks[0].voxels.is_empty());
+    assert!(decoded.chunks[0].lights.is_empty());
+}
+
+#[test]
+fn full_detail_meshes_report_lod_zero_on_wire() {
+    let registry = create_registry();
+    let config = create_config(None, false);
+
+    let chunk = mesh_terrain_chunk(&config, &registry);
+    let model = chunk.to_model(true, false, 0..4);
+    assert!(!model.meshes.is_empty());
+
+    let message = Message::new(&MessageType::Load).chunks(&[model]).build();
+    let encoded = encode_message(&message);
+    let decoded = if encoded.len() > 4096 {
+        let mut decompressed = Vec::new();
+        let mut decoder = lz4_flex::frame::FrameDecoder::new(&encoded[..]);
+        std::io::Read::read_to_end(&mut decoder, &mut decompressed).unwrap();
+        decode_message(&decompressed).unwrap()
+    } else {
+        decode_message(&encoded).unwrap()
+    };
+
+    assert!(decoded.chunks[0].meshes.iter().all(|mesh| mesh.lod == 0));
+}
+
+#[test]
+#[should_panic(expected = "Invalid chunk_lod config")]
+fn config_rejects_indivisible_max_height() {
+    WorldConfig::new()
+        .max_height(100)
+        .sub_chunks(4)
+        .chunk_lod(Some(ChunkLodConfig { max_level: 3 }))
+        .build();
+}
+
+#[test]
+#[should_panic(expected = "Invalid chunk_lod config")]
+fn config_rejects_out_of_range_level() {
+    WorldConfig::new()
+        .chunk_lod(Some(ChunkLodConfig { max_level: 5 }))
+        .build();
+}
+
+#[test]
+fn config_defaults_to_disabled() {
+    let config = WorldConfig::new().build();
+    assert!(config.chunk_lod.is_none());
+}
+
+#[test]
+fn geometry_protocol_default_has_no_lod_data() {
+    // Guard against accidental Default changes leaking LOD info into
+    // full-detail paths.
+    let geometry = GeometryProtocol::default();
+    assert!(geometry.positions.is_empty());
+    let mesh = MeshProtocol::default();
+    assert_eq!(mesh.lod, 0);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Level-of-detail for distant chunks

Opt-in per world, default OFF. A world that enables `chunk_lod` serves distant chunks as compact reduced-detail meshes, extending the visible horizon to `renderRadius * 2^maxLevel` chunks while triangle count and draw calls grow only linearly with the level count.

![Continuous LOD lighting across distant terrain and shallow water after the lattice fix](https://cursor.com/artifacts/c/art-4f2bc77d-f1fe-4812-b673-43164f945ab6)

<a href="https://cursor.com/agents/bc-f4f53396-9144-4773-9c1f-e94658a1288a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flod_textured_terrain_water_pan.mp4"><img src="https://cursor.com/artifacts/c/art-754989e0-904b-458f-b479-0b01bcb995e5" alt="lod_textured_terrain_water_pan.mp4" /></a>

## Lighting round (staging feedback: bright grid/lattice across distant terrain and water)

**Root cause — light-sampling at LOD chunk borders, not AO-per-region.** The black-cliff fix from the previous round made *every* out-of-chunk light sample read as constant full sunlight. Per-vertex face lighting averages a corner's 2x2x2 sample neighborhood, so every face touching a chunk border mixed constant 15s into its samples. Wherever the true local light is below maximum — sea floors under water, shaded valleys, slopes — border cells rendered measurably brighter than the interior one cell away, painting a bright lattice along every 16-block LOD chunk seam, across land and (through the transparent surface) across water. A secondary contributor with the same signature: AO sampled the void as permanently-open air, so border corners skipped the darkening their interior equivalents received.

**Fix — the void is a continuation of the chunk's own edge, not open sky** (`EdgeLitLodSpace` in `crates/mesher/src/lod.rs`):
- Out-of-chunk **light** samples return the border column's *surface light* — the light resting directly above that column's topmost solid cell. Over open land that is full sunlight (exposed hull cliffs stay lit, preserving the black-cliff fix); over a submerged floor it is the attenuated water light; in shaded valleys it is the dim local light. Border faces now light exactly like their interior neighbors.
- Out-of-chunk **voxel** samples clamp to the nearest in-chunk cell, so border-corner AO darkens like the equivalent interior corner.
- Occupancy (`contains`) is untouched, so hull wall emission, fluid void-face suppression, and all seam guarantees are unchanged. To make voxel mirroring safe, the mesher's buried-voxel skip is now `contains`-aware (a voxel only counts as buried when every neighbor is an *in-space* opaque voxel — behavior-identical for all existing spaces, which return air for the void).

Perf is unaffected: this changes what the server-side LOD mesher bakes per vertex, not any per-frame client work; all budgets/throttles from the perf round are untouched.

Regression tests: `lod_border_lighting_matches_interior_in_dim_light` (uniformly dim world — no border vertex may exceed the ambient level; the constant-sky behavior fails it at 12–15 vs 9) and `lod_hull_walls_are_surface_lit` (open-land cliff walls stay sunlit). Visually re-verified at altitude over the shallow-water basin and open terrain: no lattice, no periodic brightness seams.

## Performance round (staging feedback: ~40 fps with LOD on, hitches at ring swaps)

**Root causes found in the build the owner tested, all fixed:**

1. **Per-frame transparent triangle sorting over merged LOD water.** Every merged water region mesh ran `prepareTransparentMesh` + a per-frame `sortTransparentMesh` over its whole index buffer. LOD meshes now configure render order + refraction capture only.
2. **Unbudgeted, synchronous region re-merges.** Every arrival, level change, promote and demote re-merged its whole region (and re-uploaded buffers) inside that frame. Rebuilds are now **budgeted** (`maxLodRegionRebuildsPerUpdate`, default 2/frame), **cooled down** (one re-merge per region per 10 updates), and **nearest-first**. Swap commits are region-aware: a full chunk is disposed only after the region carrying its LOD replacement has re-merged, revealed only after its LOD stand-in left the scene — throttling never opens holes or double-renders.
3. **Rebuild cost.** Material resolution and flat normals moved to arrival time; a rebuild is pure buffer concatenation with the bounding sphere from merge-time bounds.
4. **Draw calls.** Region side doubled (`2^(level+2)` chunks: 8/16/32) — the whole extended horizon costs tens of draw calls.
5. **Steady-state overhead.** Region groups skip per-frame matrix updates; the periodic safety-net scan runs the tracked-state pass only (discovery sweeps only on chunk-border crossings; unflushed candidates survive maintenance scans).

**Measured (example `terrain` world, real textures, small viewport; software WebGL, so draw calls / triangles / main-thread ms are the hardware-transferable metrics):**

| Scenario | View distance | Draw calls | Triangles | Chunks loaded client-side |
|---|---|---|---|---|
| A: LOD off, `renderRadius 8` | 8 chunks | 236–241 | ~43–47k | 197 |
| B: **LOD on**, `renderRadius 8` | **32 chunks** | **287** | **~140k** | **197** |
| C: LOD off, `renderRadius 16` | 16 chunks | 1501 | ~165k | 973 |
| (extrapolated) LOD off @ 32 chunks | 32 chunks | ~6000 | ~600k | ~3200 |

At equal 32-chunk view distance, LOD-on is ~21x fewer draw calls, ~4x fewer triangles, ~16x fewer client-loaded chunks. At equal radius, LOD adds ~50 draw calls (+21%) to buy 4x view distance. Main-thread `world.update`: idle 0.1–0.4 ms (LOD on) vs 0.0–0.2 ms (off); during 25 s of continuous flight across ring boundaries: avg 1.7 ms, max 5.8 ms, zero samples above 8 ms (slow VM — faster on real hardware). Hysteresis at ring edges is unit-tested (no level flips inside the ±1-chunk band).

The example client gained measurement tooling staging can reuse: `?noLod=1` disables LOD client-side for A/B, and the debug panel shows FPS, whole-frame draw calls, and `World update (ms)`.

## Real-atlas visual round

1. **Distant water rendered as opaque teal masses with black artifacts.** Closed LOD hulls emitted *fluid* border walls against the void; between adjacent water chunks both sides emitted full-height interior walls — transparent, visible through the surface, stacking alpha into an opaque mass with near-zero baked light. Fix: fluids never emit faces against the void (both mesher face paths); the opaque sea-floor hull already closes the silhouette. Test: `lod_water_emits_no_hull_border_walls`.
2. **Black patches on distant terrain.** Exposed hull walls baked light from underground cells and the void (both zero). Fix evolved into the edge-lit space above; open-land walls stay sunlit (`lod_hull_walls_are_surface_lit`).
3. **Obvious repeating dirt texture at distance.** The greedy shader tiles textures per block via world position, so a `2^L` cell showed the texture `2^L` times per face. Fix: the client stamps the region's LOD level into bits 21..23 of the per-vertex `light` attribute and the shader divides world position by `2^level` before `fract` — texture scale locks to geometry scale; full-detail meshes carry zero bits and are byte-identical.
4. **General zoom-in weirdness.** Material bucketing mirrors material identity (water's per-face fluid geometries merge into one bucket), and merged LOD transparent meshes skip per-triangle sorting and CSM skip-list registration while keeping fluid render order and refraction capture.

## Design

### LOD scheme: geometric distance rings
Level `L` renders a chunk from a grid downsampled by `2^L` (each `2^L`-cube of voxels becomes one cell). The client maps chunk distance `d` to a level relative to its own render radius `R`: full detail for `d <= R`, level `L` for `d` in `(R * 2^(L-1), R * 2^L]`. Each ring doubles the view distance while quartering triangle density, so per-ring GPU cost is roughly constant. `max_level` is capped at 4 and validated against chunk dimensions so coarse grids always align with chunk borders.

### Seam strategy: closed hulls + conservative downsampling (why, and why not transvoxel)
Every LOD mesh is built **per chunk in isolation**: everything outside the chunk is treated as void for *occupancy*, so every solid border cell emits its border wall — each LOD chunk is a closed, watertight hull. A union of closed hulls cannot crack **no matter which levels end up adjacent**, and no chunk ever needs remeshing because a neighbor changed level. Transvoxel-style transition cells were rejected: they suit smooth isosurfaces, and coordination-based stitching puts correctness at the mercy of neighbor-level bookkeeping — where classic LOD seam bugs live. Closed hulls make watertightness a *construction property*. The closure applies to *opaque* geometry; transparent fluids skip void-facing walls. For *sampling* (light, AO), the void reads as a continuation of the chunk's edge (see the lighting round) — construction and shading are deliberately decoupled.

The full-detail boundary is covered by a conservative rule: a coarse cell is **opaque whenever it contains at least one opaque voxel**. A full-detail chunk only suppresses a border face when its true neighbor voxel is opaque; that voxel forces the neighboring coarse cell — and therefore the coarse chunk's closed wall in the very same plane — to be opaque. Every suppressed face is covered; the proof is encoded as rasterization tests. Coplanar walls face opposite directions (backface-culled, no z-fighting); non-opaque faces keep the mesher's sub-voxel inset so they are never exactly coplanar.

### Reuse of the production mesher
LOD meshing is a pure downsampling pass + the existing `mesh_space_greedy` over a virtual coarse space + a `2^L` position scale. Materials, atlas UVs, AO, fluids and transparency behave identically to full-detail meshing, and texture tiling is locked to the cell size. Representative selection is surface-biased (topmost opaque wins; leaves/glass count as mass so canopies survive; plants/fences are dropped as sub-pixel). Water cells re-encode the fluid *stage* bits so the scaled surface height lands within ~0.1–0.4 blocks of the true water level, and out-of-space fluid neighbors are treated as continuation so ocean surfaces stay flat at hull borders.

### Transitions: hysteresis + atomic, budgeted swaps
Ring boundaries carry a hysteresis band (`lodHysteresis`, default 1 chunk) so chunks never thrash between levels. Form swaps never remove a form before its replacement is fully on screen: promoted chunks build their full-detail meshes *hidden* under the LOD hull and reveal only when every sub-chunk level has meshed **and** the hull's region has re-merged without it; demoted chunks dispose their full form only after the region carrying the LOD replacement has re-merged. Region re-merges are budgeted per frame, so transitions cost a bounded slice of every frame.

### Draw calls: region batching
LOD chunk meshes merge into per-region meshes whose side doubles with the level (`2^(L+2)` chunks: 8/16/32), so every ring settles at a near-constant region count. The whole extended horizon renders in tens of draw calls with `Uint32` merged indices.

## What changed

**Server**
- `WorldConfig::chunk_lod: Option<ChunkLodConfig>` (default `None`) + validation — `server/world/chunk_lod.rs`, `config.rs`
- `Mesher::process` builds the per-chunk LOD pyramid next to normal meshing, on load and update — `generators/mesher.rs`
- `Chunk::lod_meshes` + `Chunk::to_lod_model(level)` (mesh only, no voxel/light data) — `voxels/chunk.rs`
- Per-client LOD interests (a chunk is served in exactly one form per client) — `interests.rs`
- `lodChunks: [[x, z, level]]` accepted in LOAD requests, gated on the world opt-in — `mod.rs`, `components/chunk_requests.rs`
- Request and sending systems serve/route LOD models on load and update — `systems/chunk/requests.rs`, `sending.rs`

**Mesher crate**
- `crates/mesher/src/lod.rs`: conservative downsampler, closed-hull LOD meshing, edge-lit isolated meshing space (clamp-to-edge voxels, per-column surface light)
- `crates/mesher/src/mesher.rs`: fluids never face the void; fluid corner heights treat out-of-space neighbors as continuation; buried-voxel skip is `contains`-aware

**Protocol** (additive, no version bump needed)
- `Mesh.lod` field in `messages.proto`; prost regenerates at `cargo build`, pbjs/pbts via the existing `pnpm proto` step. Round-trip coverage on both sides so a skipped regen fails loudly.

**Client (`@voxelize/core`)**
- `chunk-lod.ts`: ring math, hysteresis, `LodChunkManager` — request scheduling with retries, arrival-time geometry preparation, budgeted/cooled-down/nearest-first region re-merges, region-aware swap commits, gated discovery scans, rejoin resync, LOD level bits in the light attribute
- `shaders.ts`: `vLodTileScale` — greedy texture tiling scaled to the LOD cell size
- World integration: LOD protocol routing, full/LOD swap hooks, LOD-aware chunk retention, fog extended to the LOD horizon, identity-correct material bucketing, lean transparent setup for merged LOD meshes
- Client options: `isLodEnabled` (default true; only effective when the world opted in), `maxLodRequestsPerUpdate`, `maxLodRegionRebuildsPerUpdate`, `lodHysteresis`, `maxLodRadius`

**Example client**
- `?noLod=1` A/B switch; debug panel additions: FPS, whole-frame draw calls, `World update (ms)`

## How to enable it on a world

```rust
use voxelize::{ChunkLodConfig, WorldConfig};

let config = WorldConfig::new()
    .chunk_lod(Some(ChunkLodConfig { max_level: 2 })) // levels 1..=2, horizon = R * 4
    .build();
```

That is the entire switch — the client auto-detects `chunkLod` from the INIT options. Remove the line (or pass `None`) and every path is byte-identical to today. The example `terrain` world has it enabled as a live demonstration.

## Test coverage

- `crates/mesher/src/lod.rs` (16): downsample classification + opaque-implies-solid invariant, level monotonicity, fluid stage encoding, light maxima, closed-hull border coverage, **full-detail-to-LOD and LOD1-to-LOD2 seam watertightness** (rasterized boundary-plane proofs), no fluid hull border walls, **border lighting continuity in dim light**, surface-lit hull walls, flat border water, position scaling
- `tests/chunk_lod_tests.rs` (10): pyramid via the real `Mesher::process` pool (both meshing modes), disabled worlds pay nothing, `to_lod_model` shape, prost wire round-trip of `Mesh.lod`, config validation
- `server/world` wiring (4): LOAD json parsing incl. legacy clients, opt-in gating, end-to-end ticks from LOD request to pyramid + interest, sending-system routing by interest form
- Interests/requests (5): form exclusivity, cleanup on unload/disconnect
- `@voxelize/core` (22): ring mapping, hysteresis stability under oscillation, region keying, nearest-first requesting, region merging with offsets, LOD light bits, atomic level swaps, rebuild budget & cooldown throttling, disposal/reveal deferred until the region re-merged, stale-arrival discard, teleport unload
- `@voxelize/protocol` (3): pbjs `Mesh.lod` round-trip and legacy default

All suites green (184 lib + 34 integration + 46 crate Rust tests, 147 vitest). `tests/server_runtime.rs` contains pre-existing wall-clock-sensitive tests that flake under heavy VM load — verified they fail identically on `main` under the same load and pass on a quiet machine.

## Known limitations

- The far field must still be generated server-side before it can be LOD-meshed; first visits to a fresh procedural world fill the horizon progressively. Server memory grows with the LOD horizon.
- Blocks whose only representative has isolated (per-position) faces skip those faces in LOD meshes (rare cosmetic gap).
- Worlds with `client_only_meshing = false` still build full meshes for chunks only ever viewed as LOD.
- Edge-mirrored AO cannot see the *neighbor's* terrain steps, so AO across a cross-chunk step can be slightly brighter than a hypothetical seamless mesh — terrain-dependent and subtle, not a regular lattice.
- Ghost-flying below/inside terrain shows hull walls and voids from underneath — same class of view as being inside full-detail terrain.
- Entities/structures beyond the full-detail radius are not LOD-rendered — terrain meshes only.
- Absolute FPS could not be benchmarked on real GPU hardware in this environment (software WebGL); the draw-call / triangle / main-thread numbers are the hardware-transferable evidence, and staging should re-measure FPS with the example's `?noLod=1` A/B switch.

Staging note: enabling on a real world only requires the one-line config change above; clients need this branch's `@voxelize/core`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4f53396-9144-4773-9c1f-e94658a1288a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4f53396-9144-4773-9c1f-e94658a1288a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

